### PR TITLE
fix: do not cancel centralized order when xud goes offline

### DIFF
--- a/src/centralized/order.spec.ts
+++ b/src/centralized/order.spec.ts
@@ -9,6 +9,7 @@ let testScheduler: TestScheduler;
 type CentralizedExchangeOrderInputEvents = {
   openDEXorderFilled: string;
   createCentralizedExchangeOrder$: string;
+  unsubscribe?: string;
 };
 
 const assertCentralizedExchangeOrder = (
@@ -34,7 +35,9 @@ const assertCentralizedExchangeOrder = (
       getOpenDEXorderFilled$,
       createCentralizedExchangeOrder$,
     });
-    expectObservable(centralizedExchangeOrder$).toBe(expected);
+    expectObservable(centralizedExchangeOrder$, inputEvents.unsubscribe).toBe(
+      expected
+    );
   });
 };
 
@@ -51,6 +54,26 @@ describe('getCentralizedExchangeOrder$', () => {
       createCentralizedExchangeOrder$: '1s a',
     };
     const expected = '2s a';
+    assertCentralizedExchangeOrder(inputEvents, expected);
+  });
+
+  it('finishes centralized exchange order when OpenDEX filled stream errors afterwards', () => {
+    const inputEvents = {
+      openDEXorderFilled: '1s a #',
+      createCentralizedExchangeOrder$: '5s a',
+      unsubscribe: '7s !',
+    };
+    const expected = '6s a';
+    assertCentralizedExchangeOrder(inputEvents, expected);
+  });
+
+  it('repeats the OpenDEX order filled stream upon error', () => {
+    const inputEvents = {
+      openDEXorderFilled: '1s #',
+      createCentralizedExchangeOrder$: '5s a',
+      unsubscribe: '7s !',
+    };
+    const expected = '';
     assertCentralizedExchangeOrder(inputEvents, expected);
   });
 });

--- a/src/centralized/order.ts
+++ b/src/centralized/order.ts
@@ -1,5 +1,6 @@
-import { Observable, of } from 'rxjs';
-import { delay, mergeMap, tap } from 'rxjs/operators';
+import { empty, Observable, of } from 'rxjs';
+import { catchError, delay, mergeMap, repeat, tap } from 'rxjs/operators';
+import { RETRY_INTERVAL } from '../constants';
 import { Config } from '../config';
 import { Logger } from '../logger';
 import { GetOpenDEXorderFilledParams } from '../opendex/order-filled';
@@ -45,6 +46,10 @@ const getCentralizedExchangeOrder$ = ({
     getXudClient$,
     subscribeXudSwaps$,
   }).pipe(
+    catchError(() => {
+      return empty().pipe(delay(RETRY_INTERVAL));
+    }),
+    repeat(),
     mergeMap(() => {
       return createCentralizedExchangeOrder$(logger);
     })

--- a/src/trade/trade.spec.ts
+++ b/src/trade/trade.spec.ts
@@ -86,12 +86,11 @@ describe('getTrade$', () => {
     expect.assertions(1);
     const inputEvents = {
       openDEXcomplete$: '1s #',
-      getCentralizedExchangeOrder$: '2s #',
+      getCentralizedExchangeOrder$: '',
       shutdown$: '5s a',
     };
     const errorValues = {
       openDEXcomplete$: errors.XUD_UNAVAILABLE,
-      getCentralizedExchangeOrder$: errors.XUD_UNAVAILABLE,
     };
     const expected = '5s |';
     assertGetTrade({
@@ -105,12 +104,11 @@ describe('getTrade$', () => {
     expect.assertions(1);
     const inputEvents = {
       openDEXcomplete$: '1s #',
-      getCentralizedExchangeOrder$: '2s #',
+      getCentralizedExchangeOrder$: '',
       shutdown$: '5s a',
     };
     const errorValues = {
       openDEXcomplete$: errors.XUD_LOCKED,
-      getCentralizedExchangeOrder$: errors.XUD_LOCKED,
     };
     const expected = '5s |';
     assertGetTrade({
@@ -124,14 +122,11 @@ describe('getTrade$', () => {
     expect.assertions(1);
     const inputEvents = {
       openDEXcomplete$: '1s #',
-      getCentralizedExchangeOrder$: '2s #',
+      getCentralizedExchangeOrder$: '',
       shutdown$: '5s a',
     };
     const errorValues = {
       openDEXcomplete$: errors.XUD_CLIENT_INVALID_CERT('/invalid/cert/path'),
-      getCentralizedExchangeOrder$: errors.XUD_CLIENT_INVALID_CERT(
-        '/invalid/cert/path'
-      ),
     };
     const expected = '5s |';
     assertGetTrade({
@@ -145,12 +140,11 @@ describe('getTrade$', () => {
     expect.assertions(1);
     const inputEvents = {
       openDEXcomplete$: '1s #',
-      getCentralizedExchangeOrder$: '2s #',
+      getCentralizedExchangeOrder$: '',
       shutdown$: '5s a',
     };
     const errorValues = {
       openDEXcomplete$: errors.BALANCE_MISSING('ETH'),
-      getCentralizedExchangeOrder$: errors.BALANCE_MISSING('BTC'),
     };
     const expected = '5s |';
     assertGetTrade({
@@ -164,12 +158,11 @@ describe('getTrade$', () => {
     expect.assertions(1);
     const inputEvents = {
       openDEXcomplete$: '1s #',
-      getCentralizedExchangeOrder$: '2s #',
+      getCentralizedExchangeOrder$: '',
       shutdown$: '5s a',
     };
     const errorValues = {
       openDEXcomplete$: errors.TRADING_LIMITS_MISSING('BTC'),
-      getCentralizedExchangeOrder$: errors.TRADING_LIMITS_MISSING('ETH'),
     };
     const expected = '5s |';
     assertGetTrade({
@@ -183,12 +176,11 @@ describe('getTrade$', () => {
     expect.assertions(1);
     const inputEvents = {
       openDEXcomplete$: '1s #',
-      getCentralizedExchangeOrder$: '2s #',
+      getCentralizedExchangeOrder$: '',
       shutdown$: '5s a',
     };
     const errorValues = {
       openDEXcomplete$: errors.INVALID_ORDERS_LIST('ETH/BTC'),
-      getCentralizedExchangeOrder$: errors.INVALID_ORDERS_LIST('ETH/BTC'),
     };
     const expected = '5s |';
     assertGetTrade({
@@ -202,13 +194,11 @@ describe('getTrade$', () => {
     expect.assertions(1);
     const inputEvents = {
       openDEXcomplete$: '1s #',
-      getCentralizedExchangeOrder$: '2s #',
+      getCentralizedExchangeOrder$: '',
       shutdown$: '5s a',
     };
     const errorValues = {
       openDEXcomplete$: errors.CENTRALIZED_EXCHANGE_PRICE_FEED_ERROR,
-      getCentralizedExchangeOrder$:
-        errors.CENTRALIZED_EXCHANGE_PRICE_FEED_ERROR,
     };
     const expected = '5s |';
     assertGetTrade({
@@ -222,12 +212,11 @@ describe('getTrade$', () => {
     expect.assertions(1);
     const inputEvents = {
       openDEXcomplete$: '1s #',
-      getCentralizedExchangeOrder$: '2s #',
+      getCentralizedExchangeOrder$: '',
       shutdown$: '5s a',
     };
     const errorValues = {
       openDEXcomplete$: errors.INSUFFICIENT_OUTBOUND_BALANCE,
-      getCentralizedExchangeOrder$: errors.INSUFFICIENT_OUTBOUND_BALANCE,
     };
     const expected = '5s |';
     assertGetTrade({

--- a/src/trade/trade.ts
+++ b/src/trade/trade.ts
@@ -94,7 +94,7 @@ const getNewTrade$ = ({
       config,
       getOpenDEXorderFilled$,
       createCentralizedExchangeOrder$,
-    }).pipe(catchArbyError(loggers))
+    })
   ).pipe(mapTo(true), repeat(), takeUntil(shutdown$));
 };
 


### PR DESCRIPTION
Fixes https://github.com/ExchangeUnion/market-maker-tools/issues/24