### PR TITLE
add debug logging around updating orders

### DIFF
--- a/src/opendex/create-orders.ts
+++ b/src/opendex/create-orders.ts
@@ -49,6 +49,7 @@ const createOpenDEXorders$ = ({
   createXudOrder$,
 }: CreateOpenDEXordersParams): Observable<boolean> => {
   return getXudClient$(config).pipe(
+    tap(() => logger.trace('Starting to update OpenDEX orders')),
     // remove all existing orders
     mergeMap(client => {
       return removeOpenDEXorders$({
@@ -83,7 +84,7 @@ const createOpenDEXorders$ = ({
       const ordersComplete$ = forkJoin(sellOrder$, buyOrder$).pipe(mapTo(true));
       return ordersComplete$;
     }),
-    tap(() => logger.trace('OpenDEX orders updated.')),
+    tap(() => logger.trace('OpenDEX orders updated')),
     take(1)
   );
 };

--- a/src/opendex/xud/create-order.ts
+++ b/src/opendex/xud/create-order.ts
@@ -1,5 +1,5 @@
 import { Observable, of } from 'rxjs';
-import { take } from 'rxjs/operators';
+import { take, tap } from 'rxjs/operators';
 import { Logger } from '../../logger';
 import { XudClient } from '../../proto/xudrpc_grpc_pb';
 import { PlaceOrderRequest, PlaceOrderResponse } from '../../proto/xudrpc_pb';
@@ -50,9 +50,17 @@ const createXudOrder$ = ({
           parseGrpcError,
         })
       );
-    }).pipe(take(1));
+    }).pipe(
+      tap(() => {
+        logger.trace(`Order ${orderId} created`);
+      }),
+      take(1)
+    );
     return createXudOrder$ as Observable<PlaceOrderResponse>;
   } else {
+    logger.trace(
+      `Did not create ${orderSideMapping[orderSide]} order because calculated quantity was 0`
+    );
     return of((null as unknown) as PlaceOrderResponse);
   }
 };


### PR DESCRIPTION
This commit adds more logging around the order update flow:
```
[1] 2020-06-22 03:20:29.2929 [OpenDEX] trace: Starting to update OpenDEX orders
[1] 2020-06-22 03:20:29.2929 [OpenDEX] trace: Removed all open orders for ETH/BTC
[1] 2020-06-22 03:20:29.2929 [OpenDEX] trace: Creating ETH/BTC buy order with id 1b660941-a1c1-407d-bc15-e6c431ef9f7c, quantity 3.73365697 and price 0.02365228
[1] 2020-06-22 03:20:29.2929 [OpenDEX] trace: Creating ETH/BTC sell order with id 8ab215bb-3906-4100-891d-4bca3f0e2319, quantity 2.56451402 and price 0.02667172
[1] 2020-06-22 03:20:30.3030 [OpenDEX] trace: Order 8ab215bb-3906-4100-891d-4bca3f0e2319 created
[1] 2020-06-22 03:20:30.3030 [OpenDEX] trace: Order 1b660941-a1c1-407d-bc15-e6c431ef9f7c created
[1] 2020-06-22 03:20:30.3030 [OpenDEX] trace: OpenDEX orders updated
```