### PR TITLE
Cancel orders on shutdown

### DIFF
--- a/src/arby.spec.ts
+++ b/src/arby.spec.ts
@@ -4,9 +4,41 @@ import { startArby } from '../src/arby';
 import { Config } from '../src/config';
 import { getLoggers } from './test-utils';
 
-describe('startArby', () => {
-  let testScheduler: TestScheduler;
+let testScheduler: TestScheduler;
 
+type AssertStartArbyParams = {
+  expected: string;
+  inputEvents: {
+    config$: string;
+    getTrade$: string;
+    shutdown$: string;
+    cleanup$: string;
+  };
+};
+
+const assertStartArby = ({ expected, inputEvents }: AssertStartArbyParams) => {
+  testScheduler.run(helpers => {
+    const { cold, expectObservable } = helpers;
+    const config$ = cold(inputEvents.config$) as Observable<Config>;
+    const getTrade$ = () => {
+      return (cold(inputEvents.getTrade$) as unknown) as Observable<boolean>;
+    };
+    const shutdown$ = cold(inputEvents.shutdown$);
+    const cleanup$ = () => {
+      return cold(inputEvents.cleanup$);
+    };
+    const arby$ = startArby({
+      config$,
+      getLoggers,
+      shutdown$,
+      trade$: getTrade$,
+      cleanup$,
+    });
+    expectObservable(arby$).toBe(expected);
+  });
+};
+
+describe('startArby', () => {
   beforeEach(() => {
     testScheduler = new TestScheduler((actual, expected) => {
       expect(actual).toEqual(expected);
@@ -14,44 +46,30 @@ describe('startArby', () => {
   });
 
   it('waits for valid configuration before starting', () => {
-    testScheduler.run(helpers => {
-      const { cold, expectObservable } = helpers;
-      const config$ = cold('1000ms a') as Observable<Config>;
-      const getTrade$ = () => {
-        return cold('b', { b: true });
-      };
-      const shutdown$ = cold('');
-      const arby$ = startArby({
-        config$,
-        getLoggers,
-        shutdown$,
-        trade$: getTrade$,
-      });
-      const expected = '1000ms b';
-      expectObservable(arby$).toBe(expected, {
-        b: true,
-      });
+    const inputEvents = {
+      config$: '1000ms a',
+      getTrade$: 'b',
+      shutdown$: '',
+      cleanup$: '',
+    };
+    const expected = '1000ms b';
+    assertStartArby({
+      inputEvents,
+      expected,
     });
   });
 
-  it('stops gracefully when kill signal received', () => {
-    testScheduler.run(helpers => {
-      const { cold, expectObservable } = helpers;
-      const config$ = cold('a') as Observable<Config>;
-      const getTrade$ = () => {
-        return cold('500ms b', { b: true });
-      };
-      const shutdown$ = cold('10s c');
-      const arby$ = startArby({
-        config$,
-        getLoggers,
-        trade$: getTrade$,
-        shutdown$,
-      });
-      const expected = '500ms b 9499ms |';
-      expectObservable(arby$).toBe(expected, {
-        b: true,
-      });
+  it('performs cleanup when shutting down gracefully', () => {
+    const inputEvents = {
+      config$: 'a',
+      getTrade$: '500ms b',
+      shutdown$: '10s c',
+      cleanup$: '2s a',
+    };
+    const expected = '500ms b 11499ms a';
+    assertStartArby({
+      inputEvents,
+      expected,
     });
   });
 });

--- a/src/centralized/remove-orders.ts
+++ b/src/centralized/remove-orders.ts
@@ -1,0 +1,13 @@
+import { of } from 'rxjs';
+import { delay, tap } from 'rxjs/operators';
+import { Logger } from '../logger';
+
+const removeCEXorders$ = (logger: Logger) => {
+  return of(null).pipe(
+    tap(() => logger.info('Removing CEX orders')),
+    delay(1000),
+    tap(() => logger.info('Finished removing CEX orders'))
+  );
+};
+
+export { removeCEXorders$ };

--- a/src/trade/cleanup.spec.ts
+++ b/src/trade/cleanup.spec.ts
@@ -1,0 +1,57 @@
+import { TestScheduler } from 'rxjs/testing';
+import { getCleanup$ } from './cleanup';
+import { testConfig, getLoggers } from '../test-utils';
+import { Observable } from 'rxjs';
+
+let testScheduler: TestScheduler;
+const testSchedulerSetup = () => {
+  testScheduler = new TestScheduler((actual, expected) => {
+    expect(actual).toEqual(expected);
+  });
+};
+
+type AssertCleanupParams = {
+  expected: string;
+  inputEvents: {
+    removeOpenDEXorders$: string;
+    removeCEXorders$: string;
+  };
+};
+
+const assertGetTrade = ({ expected, inputEvents }: AssertCleanupParams) => {
+  testScheduler.run(helpers => {
+    const { cold, expectObservable } = helpers;
+    const removeOpenDEXorders$ = () => {
+      return (cold(inputEvents.removeOpenDEXorders$) as unknown) as Observable<
+        null
+      >;
+    };
+    const removeCEXorders$ = () => {
+      return cold(inputEvents.removeCEXorders$);
+    };
+    const cleanup$ = getCleanup$({
+      loggers: getLoggers(),
+      config: testConfig(),
+      removeOpenDEXorders$,
+      removeCEXorders$,
+    });
+    expectObservable(cleanup$).toBe(expected);
+  });
+};
+
+describe('getCleanup$$', () => {
+  beforeEach(testSchedulerSetup);
+
+  it('removes all orders on OpenDEX and CEX', () => {
+    expect.assertions(1);
+    const inputEvents = {
+      removeOpenDEXorders$: '1s a',
+      removeCEXorders$: '2s a',
+    };
+    const expected = '2s |';
+    assertGetTrade({
+      inputEvents,
+      expected,
+    });
+  });
+});

--- a/src/trade/cleanup.ts
+++ b/src/trade/cleanup.ts
@@ -1,7 +1,47 @@
-import { Observable, of } from 'rxjs';
+import { combineLatest, Observable } from 'rxjs';
+import { ignoreElements, take, tap } from 'rxjs/operators';
+import { Config } from '../config';
+import { Logger, Loggers } from '../logger';
+import { processListorders } from '../opendex/process-listorders';
+import { RemoveOpenDEXordersParams } from '../opendex/remove-orders';
+import { getXudClient$ } from '../opendex/xud/client';
+import { listXudOrders$ } from '../opendex/xud/list-orders';
+import { removeXudOrder$ } from '../opendex/xud/remove-order';
 
-const getCleanup$ = (): Observable<unknown> => {
-  return of('cleanup complete');
+type GetCleanupParams = {
+  loggers: Loggers;
+  config: Config;
+  removeOpenDEXorders$: ({
+    config,
+    getXudClient$,
+    listXudOrders$,
+    removeXudOrder$,
+    processListorders,
+  }: RemoveOpenDEXordersParams) => Observable<null>;
+  removeCEXorders$: (logger: Logger) => Observable<unknown>;
 };
 
-export { getCleanup$ };
+const getCleanup$ = ({
+  config,
+  loggers,
+  removeOpenDEXorders$,
+  removeCEXorders$,
+}: GetCleanupParams): Observable<unknown> => {
+  loggers.global.info('Cleaning up all orders before shutting down');
+  return combineLatest(
+    removeOpenDEXorders$({
+      config,
+      getXudClient$,
+      listXudOrders$,
+      removeXudOrder$,
+      processListorders,
+    }).pipe(
+      tap(() => {
+        loggers.opendex.info('All OpenDEX orders have been removed');
+      })
+    ),
+    removeCEXorders$(loggers.centralized)
+  ).pipe(take(1), ignoreElements());
+};
+
+export { getCleanup$, GetCleanupParams };

--- a/src/trade/cleanup.ts
+++ b/src/trade/cleanup.ts
@@ -1,0 +1,7 @@
+import { Observable, of } from 'rxjs';
+
+const getCleanup$ = (): Observable<unknown> => {
+  return of('cleanup complete');
+};
+
+export { getCleanup$ };

--- a/src/trade/trade.ts
+++ b/src/trade/trade.ts
@@ -1,5 +1,5 @@
 import { merge, Observable } from 'rxjs';
-import { ignoreElements, mapTo, repeat, takeUntil } from 'rxjs/operators';
+import { ignoreElements, mapTo, repeat, takeUntil, tap } from 'rxjs/operators';
 import {
   createCentralizedExchangeOrder$,
   GetCentralizedExchangeOrderParams,
@@ -51,7 +51,14 @@ const getNewTrade$ = ({
       getOpenDEXorderFilled$,
       createCentralizedExchangeOrder$,
     })
-  ).pipe(mapTo(true), repeat(), takeUntil(shutdown$));
+  ).pipe(
+    tap(() => {
+      loggers.global.info('Trade complete');
+    }),
+    mapTo(true),
+    repeat(),
+    takeUntil(shutdown$)
+  );
 };
 
 export { getNewTrade$, GetTradeParams };


### PR DESCRIPTION
This PR implements cleanup flow that will cancel OpenDEX and CEX orders before shutting down gracefully.

Closes https://github.com/ExchangeUnion/market-maker-tools/issues/27