### PR TITLE
fix(test): avoid Binance API calls in tests

### DIFF
--- a/src/arby.ts
+++ b/src/arby.ts
@@ -1,5 +1,6 @@
 import { concat, Observable } from 'rxjs';
 import { mergeMap, takeUntil } from 'rxjs/operators';
+import { initBinance$ } from './centralized/ccxt/init';
 import { getCentralizedExchangePrice$ } from './centralized/exchange-price';
 import { getCentralizedExchangeOrder$ } from './centralized/order';
 import { removeCEXorders$ } from './centralized/remove-orders';
@@ -77,6 +78,7 @@ export const startArby = ({
         getCentralizedExchangeOrder$,
         catchOpenDEXerror,
         getCentralizedExchangePrice$,
+        initBinance$,
       }).pipe(takeUntil(shutdown$));
       return concat(
         tradeComplete$,

--- a/src/centralized/ccxt/init.ts
+++ b/src/centralized/ccxt/init.ts
@@ -18,4 +18,4 @@ const initBinance$ = ({
   return loadMarkets$(exchange).pipe(mapTo(exchange));
 };
 
-export { initBinance$ };
+export { initBinance$, InitBinanceParams };

--- a/src/trade/trade.spec.ts
+++ b/src/trade/trade.spec.ts
@@ -4,6 +4,7 @@ import { TestScheduler } from 'rxjs/testing';
 import { getLoggers, testConfig, TestError } from '../test-utils';
 import { getNewTrade$ } from './trade';
 import BigNumber from 'bignumber.js';
+import { Exchange } from 'ccxt';
 
 let testScheduler: TestScheduler;
 const testSchedulerSetup = () => {
@@ -71,7 +72,11 @@ const assertGetTrade = ({
     const getCentralizedExchangePrice$ = () => {
       return (cold('') as unknown) as Observable<BigNumber>;
     };
+    const initBinance$ = () => {
+      return (cold('') as unknown) as Observable<Exchange>;
+    };
     const trade$ = getNewTrade$({
+      initBinance$,
       shutdown$,
       loggers: getLoggers(),
       getOpenDEXcomplete$,

--- a/src/trade/trade.ts
+++ b/src/trade/trade.ts
@@ -1,18 +1,19 @@
 import BigNumber from 'bignumber.js';
+import { Exchange } from 'ccxt';
 import { merge, Observable } from 'rxjs';
 import { ignoreElements, mapTo, repeat, takeUntil, tap } from 'rxjs/operators';
-import { initBinance$ } from '../centralized/ccxt/init';
+import { getExchange } from '../centralized/ccxt/exchange';
+import { InitBinanceParams } from '../centralized/ccxt/init';
 import { loadMarkets$ } from '../centralized/ccxt/load-markets';
 import { CentralizedExchangePriceParams } from '../centralized/exchange-price';
-import { GetCentralizedExchangeOrderParams } from '../centralized/order';
 import { executeCEXorder$ } from '../centralized/execute-order';
+import { GetCentralizedExchangeOrderParams } from '../centralized/order';
 import { getOrderBuilder$ } from '../centralized/order-builder';
 import { Config } from '../config';
 import { Loggers } from '../logger';
 import { GetOpenDEXcompleteParams } from '../opendex/complete';
 import { createOpenDEXorders$ } from '../opendex/create-orders';
 import { getTradeInfo$ } from './info';
-import { getExchange } from '../centralized/ccxt/exchange';
 
 type GetTradeParams = {
   config: Config;
@@ -35,6 +36,11 @@ type GetTradeParams = {
     logger,
     config,
   }: CentralizedExchangePriceParams) => Observable<BigNumber>;
+  initBinance$: ({
+    getExchange,
+    config,
+    loadMarkets$,
+  }: InitBinanceParams) => Observable<Exchange>;
 };
 
 const getNewTrade$ = ({
@@ -45,6 +51,7 @@ const getNewTrade$ = ({
   shutdown$,
   catchOpenDEXerror,
   getCentralizedExchangePrice$,
+  initBinance$,
 }: GetTradeParams): Observable<boolean> => {
   const centralizedExchangePrice$ = getCentralizedExchangePrice$({
     config,


### PR DESCRIPTION
This commit fixes an issue with the `trade.spec` that was making real
API calls to Binance API. As a result, it was causing the test suite to
occasionally fail.