### PR TITLE
only count UNAVAILABLE error retry attempts

### DIFF
--- a/src/test-utils.ts
+++ b/src/test-utils.ts
@@ -26,6 +26,7 @@ const getLoggers = (): Loggers => {
     verbose: () => {},
     debug: () => {},
     trace: () => {},
+    error: () => {},
   };
   return ({
     global: mockLogger,


### PR DESCRIPTION
This PR changes the logic of error handling to only count gRPC UNAVAILABLE errors towards the retry threshold. Previously all errors were counted.