### PR TITLE
add trading pair validation to config

### DIFF
--- a/src/__snapshots__/config.spec.ts.snap
+++ b/src/__snapshots__/config.spec.ts.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`checkConfigOptions does not allow LTC/LTC trading pair 1`] = `"Invalid trading pair LTC/LTC. Supported trading pairs are: ETH/BTC, BTC/USDT"`;

--- a/src/config.spec.ts
+++ b/src/config.spec.ts
@@ -1,0 +1,70 @@
+import { checkConfigOptions } from './config';
+
+describe('checkConfigOptions', () => {
+  it('allows BTC/USDT trading pair', () => {
+    const dotEnvConfig = {
+      LOG_LEVEL: 'trace',
+      BINANCE_API_KEY: '123',
+      BINANCE_API_SECRET: 'abc',
+      DATA_DIR: '/some/data/path',
+      OPENDEX_CERT_PATH: '/some/cert/path',
+      OPENDEX_RPC_HOST: 'localhost',
+      OPENDEX_RPC_PORT: '1234',
+      MARGIN: '0.06',
+      BASEASSET: 'BTC',
+      QUOTEASSET: 'USDT',
+      TEST_CENTRALIZED_EXCHANGE_BASEASSET_BALANCE: '321',
+      TEST_CENTRALIZED_EXCHANGE_QUOTEASSET_BALANCE: '123',
+      LIVE_CEX: 'false',
+    };
+    const verifiedConfig = checkConfigOptions(dotEnvConfig);
+    expect(verifiedConfig).toEqual({
+      ...dotEnvConfig,
+      LIVE_CEX: false,
+    });
+  });
+
+  it('allows ETH/BTC trading pair', () => {
+    const dotEnvConfig = {
+      LOG_LEVEL: 'trace',
+      BINANCE_API_KEY: '123',
+      BINANCE_API_SECRET: 'abc',
+      DATA_DIR: '/some/data/path',
+      OPENDEX_CERT_PATH: '/some/cert/path',
+      OPENDEX_RPC_HOST: 'localhost',
+      OPENDEX_RPC_PORT: '1234',
+      MARGIN: '0.06',
+      BASEASSET: 'ETH',
+      QUOTEASSET: 'BTC',
+      TEST_CENTRALIZED_EXCHANGE_BASEASSET_BALANCE: '321',
+      TEST_CENTRALIZED_EXCHANGE_QUOTEASSET_BALANCE: '123',
+      LIVE_CEX: 'false',
+    };
+    const verifiedConfig = checkConfigOptions(dotEnvConfig);
+    expect(verifiedConfig).toEqual({
+      ...dotEnvConfig,
+      LIVE_CEX: false,
+    });
+  });
+
+  it('does not allow LTC/LTC trading pair', () => {
+    const dotEnvConfig = {
+      LOG_LEVEL: 'trace',
+      BINANCE_API_KEY: '123',
+      BINANCE_API_SECRET: 'abc',
+      DATA_DIR: '/some/data/path',
+      OPENDEX_CERT_PATH: '/some/cert/path',
+      OPENDEX_RPC_HOST: 'localhost',
+      OPENDEX_RPC_PORT: '1234',
+      MARGIN: '0.06',
+      BASEASSET: 'LTC',
+      QUOTEASSET: 'LTC',
+      TEST_CENTRALIZED_EXCHANGE_BASEASSET_BALANCE: '321',
+      TEST_CENTRALIZED_EXCHANGE_QUOTEASSET_BALANCE: '123',
+      LIVE_CEX: 'false',
+    };
+    expect(() => {
+      checkConfigOptions(dotEnvConfig);
+    }).toThrowErrorMatchingSnapshot();
+  });
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -73,6 +73,8 @@ const getMissingOptions = (config: DotenvParseOutput): string => {
   ).join(', ');
 };
 
+const ALLOWED_TRADING_PAIRS: string[] = ['ETH/BTC', 'BTC/USDT'];
+
 const checkConfigOptions = (dotEnvConfig: DotenvParseOutput): Config => {
   const config = {
     ...dotEnvConfig,
@@ -84,6 +86,14 @@ const checkConfigOptions = (dotEnvConfig: DotenvParseOutput): Config => {
       `Incomplete configuration. Please add the following options to .env or as environment variables: ${missingOptions}`
     );
   }
+  const tradingPair = `${config.BASEASSET}/${config.QUOTEASSET}`;
+  if (!ALLOWED_TRADING_PAIRS.includes(tradingPair)) {
+    throw new Error(
+      `Invalid trading pair ${tradingPair}. Supported trading pairs are: ${ALLOWED_TRADING_PAIRS.join(
+        ', '
+      )}`
+    );
+  }
   const verifiedConfig = {
     ...config,
     LOG_LEVEL: setLogLevel(config.LOG_LEVEL),
@@ -92,9 +102,11 @@ const checkConfigOptions = (dotEnvConfig: DotenvParseOutput): Config => {
   return verifiedConfig as Config;
 };
 
-export const getConfig$ = (): Observable<Config> => {
+const getConfig$ = (): Observable<Config> => {
   return of(require('dotenv').config()).pipe(
     pluck('parsed'),
     map(checkConfigOptions)
   );
 };
+
+export { getConfig$, checkConfigOptions };


### PR DESCRIPTION
This commit verifies that arby is started with a supported trading pair
(currently ETH/BTC or BTC/USDT).