### PR TITLE
feat: replace order

### DIFF
--- a/src/opendex/complete.ts
+++ b/src/opendex/complete.ts
@@ -1,6 +1,8 @@
 import { BigNumber } from 'bignumber.js';
+import { Exchange } from 'ccxt';
 import { Observable } from 'rxjs';
 import { exhaustMap } from 'rxjs/operators';
+import { getCentralizedExchangeAssets$ } from '../centralized/assets';
 import { Config } from '../config';
 import { Loggers } from '../logger';
 import {
@@ -12,13 +14,10 @@ import { getOpenDEXassets$ } from './assets';
 import { logAssetBalance, parseOpenDEXassets } from './assets-utils';
 import { CreateOpenDEXordersParams } from './create-orders';
 import { tradeInfoToOpenDEXorders } from './orders';
-import { removeOpenDEXorders$ } from './remove-orders';
 import { getXudBalance$ } from './xud/balance';
 import { getXudClient$ } from './xud/client';
 import { createXudOrder$ } from './xud/create-order';
 import { getXudTradingLimits$ } from './xud/trading-limits';
-import { getCentralizedExchangeAssets$ } from '../centralized/assets';
-import { Exchange } from 'ccxt';
 
 type GetOpenDEXcompleteParams = {
   config: Config;
@@ -82,7 +81,6 @@ const getOpenDEXcomplete$ = ({
         getTradeInfo,
         getXudClient$,
         createXudOrder$,
-        removeOpenDEXorders$,
         tradeInfoToOpenDEXorders,
       });
     })

--- a/src/opendex/create-orders.spec.ts
+++ b/src/opendex/create-orders.spec.ts
@@ -1,3 +1,4 @@
+import { status } from '@grpc/grpc-js';
 import { Observable } from 'rxjs';
 import { TestScheduler } from 'rxjs/testing';
 import { XudClient } from '../proto/xudrpc_grpc_pb';
@@ -5,6 +6,7 @@ import { PlaceOrderResponse } from '../proto/xudrpc_pb';
 import { getLoggers, testConfig } from '../test-utils';
 import { TradeInfo } from '../trade/info';
 import { createOpenDEXorders$, OpenDEXorders } from './create-orders';
+import { TestError } from '../test-utils';
 
 let testScheduler: TestScheduler;
 const testSchedulerSetup = () => {
@@ -16,19 +18,36 @@ const testSchedulerSetup = () => {
 type CreateOpenDEXordersInputEvents = {
   xudClient$: string;
   xudOrder$: string;
+  replaceXudOrder$: string;
 };
 
 const assertCreateOpenDEXorders = (
   inputEvents: CreateOpenDEXordersInputEvents,
-  expected: string
+  expected: string,
+  inputErrors?: {
+    xudOrder$?: TestError;
+    replaceXudOrder$?: TestError;
+  }
 ) => {
   testScheduler.run(helpers => {
     const { cold, expectObservable } = helpers;
     const getTradeInfo = (): TradeInfo => {
       return ('mock trade info' as unknown) as TradeInfo;
     };
-    const createXudOrder$ = () => {
-      return cold(inputEvents.xudOrder$) as Observable<PlaceOrderResponse>;
+    const createXudOrder$ = (createOrderParams: any) => {
+      if (createOrderParams.replaceOrderId) {
+        return cold(
+          inputEvents.replaceXudOrder$,
+          {},
+          inputErrors?.replaceXudOrder$
+        ) as Observable<PlaceOrderResponse>;
+      } else {
+        return cold(
+          inputEvents.xudOrder$,
+          {},
+          inputErrors?.xudOrder$
+        ) as Observable<PlaceOrderResponse>;
+      }
     };
     const getXudClient$ = () => {
       return cold(inputEvents.xudClient$) as Observable<XudClient>;
@@ -56,9 +75,36 @@ describe('createOpenDEXorders$', () => {
   it('creates buy and sell orders', () => {
     const inputEvents = {
       xudClient$: '1s a',
-      xudOrder$: '1s (a|)',
+      replaceXudOrder$: '1s (a|)',
+      xudOrder$: '',
     };
     const expected = '2s (a|)';
     assertCreateOpenDEXorders(inputEvents, expected);
+  });
+
+  it('throws if unknown error for repace order', () => {
+    const inputEvents = {
+      xudClient$: '1s a',
+      replaceXudOrder$: '1s #',
+      xudOrder$: '',
+    };
+    const expected = '2s #';
+    assertCreateOpenDEXorders(inputEvents, expected);
+  });
+
+  it('retries without replaceOrderId if grpc.NOT_FOUND error', () => {
+    const inputEvents = {
+      xudClient$: '1s a',
+      xudOrder$: '1s (a|)',
+      replaceXudOrder$: '1s #',
+    };
+    const inputErrors = {
+      replaceXudOrder$: {
+        code: status.NOT_FOUND,
+        message: 'NOT FOUND',
+      },
+    };
+    const expected = '3s (a|)';
+    assertCreateOpenDEXorders(inputEvents, expected, inputErrors);
   });
 });

--- a/src/opendex/create-orders.spec.ts
+++ b/src/opendex/create-orders.spec.ts
@@ -16,7 +16,6 @@ const testSchedulerSetup = () => {
 type CreateOpenDEXordersInputEvents = {
   xudClient$: string;
   xudOrder$: string;
-  removeOpenDEXorders$: string;
 };
 
 const assertCreateOpenDEXorders = (
@@ -34,9 +33,6 @@ const assertCreateOpenDEXorders = (
     const getXudClient$ = () => {
       return cold(inputEvents.xudClient$) as Observable<XudClient>;
     };
-    const removeOpenDEXorders$ = () => {
-      return cold(inputEvents.removeOpenDEXorders$) as Observable<null>;
-    };
     const tradeInfoToOpenDEXorders = (v: any) => {
       return (v as unknown) as OpenDEXorders;
     };
@@ -45,7 +41,6 @@ const assertCreateOpenDEXorders = (
       getXudClient$,
       createXudOrder$,
       tradeInfoToOpenDEXorders,
-      removeOpenDEXorders$,
       logger: getLoggers().global,
       config: testConfig(),
     });
@@ -61,10 +56,9 @@ describe('createOpenDEXorders$', () => {
   it('creates buy and sell orders', () => {
     const inputEvents = {
       xudClient$: '1s a',
-      removeOpenDEXorders$: '4s a',
       xudOrder$: '1s (a|)',
     };
-    const expected = '6s (a|)';
+    const expected = '2s (a|)';
     assertCreateOpenDEXorders(inputEvents, expected);
   });
 });

--- a/src/opendex/create-orders.ts
+++ b/src/opendex/create-orders.ts
@@ -46,10 +46,12 @@ const createOpenDEXorders$ = ({
     tap(() => logger.trace('Starting to update OpenDEX orders')),
     // create new buy and sell orders
     mergeMap(client => {
+      // build orders based on all the available trade info
       const { buyOrder, sellOrder } = tradeInfoToOpenDEXorders({
         config,
         tradeInfo: getTradeInfo(),
       });
+      // try replacing existing buy order
       const buyOrder$ = createXudOrder$({
         ...{ client, logger },
         ...buyOrder,
@@ -59,6 +61,7 @@ const createOpenDEXorders$ = ({
       }).pipe(
         catchError(e => {
           if (e.code === status.NOT_FOUND) {
+            // place order if existing one does not exist
             return createXudOrder$({
               ...{ client, logger },
               ...buyOrder,
@@ -67,6 +70,7 @@ const createOpenDEXorders$ = ({
           return throwError(e);
         })
       );
+      // try replacing existing sell order
       const sellOrder$ = createXudOrder$({
         ...{ client, logger },
         ...sellOrder,
@@ -76,6 +80,7 @@ const createOpenDEXorders$ = ({
       }).pipe(
         catchError(e => {
           if (e.code === status.NOT_FOUND) {
+            // place order if existing one does not exist
             return createXudOrder$({
               ...{ client, logger },
               ...sellOrder,

--- a/src/opendex/orders.spec.ts
+++ b/src/opendex/orders.spec.ts
@@ -33,7 +33,7 @@ const assertTradeInfoToOpenDEXorders = ({
         orderSide: OrderSide.BUY,
         pairId,
         price: expected.buyPrice.toNumber(),
-        orderId: expect.any(String),
+        orderId: 'arby-ETH/BTC-buy-order',
       })
     );
   }
@@ -46,7 +46,7 @@ const assertTradeInfoToOpenDEXorders = ({
         orderSide: OrderSide.SELL,
         pairId,
         price: expected.sellPrice.toNumber(),
-        orderId: expect.any(String),
+        orderId: 'arby-ETH/BTC-sell-order',
       })
     );
   }

--- a/src/opendex/orders.ts
+++ b/src/opendex/orders.ts
@@ -1,5 +1,4 @@
 import BigNumber from 'bignumber.js';
-import { v4 as uuidv4 } from 'uuid';
 import { Config } from '../config';
 import { OrderSide } from '../proto/xudrpc_pb';
 import { TradeInfo } from '../trade/info';
@@ -22,6 +21,13 @@ type OpenDEXorders = {
 type TradeInfoToOpenDEXordersParams = {
   tradeInfo: TradeInfo;
   config: Config;
+};
+
+const createOrderID = (config: Config, orderSide: OrderSide): string => {
+  const pairId = `${config.BASEASSET}/${config.QUOTEASSET}`;
+  return orderSide === OrderSide.BUY
+    ? `arby-${pairId}-buy-order`
+    : `arby-${pairId}-sell-order`;
 };
 
 const tradeInfoToOpenDEXorders = ({
@@ -60,14 +66,14 @@ const tradeInfoToOpenDEXorders = ({
     orderSide: OrderSide.BUY,
     pairId,
     price: buyPrice.toNumber(),
-    orderId: uuidv4(),
+    orderId: createOrderID(config, OrderSide.BUY),
   };
   const sellOrder = {
     quantity: coinsToSats(new BigNumber(sellQuantity.toFixed(8, 1)).toNumber()),
     orderSide: OrderSide.SELL,
     pairId,
     price: sellPrice.toNumber(),
-    orderId: uuidv4(),
+    orderId: createOrderID(config, OrderSide.SELL),
   };
   return {
     buyOrder,
@@ -79,5 +85,6 @@ export {
   OpenDEXorders,
   OpenDEXorder,
   tradeInfoToOpenDEXorders,
+  createOrderID,
   TradeInfoToOpenDEXordersParams,
 };

--- a/src/opendex/orders.ts
+++ b/src/opendex/orders.ts
@@ -11,6 +11,7 @@ type OpenDEXorder = {
   pairId: string;
   price: number;
   orderId: string;
+  replaceOrderId?: string;
 };
 
 type OpenDEXorders = {

--- a/src/opendex/xud/create-order.ts
+++ b/src/opendex/xud/create-order.ts
@@ -27,10 +27,12 @@ const createXudOrder$ = ({
   pairId,
   price,
   orderId,
+  replaceOrderId,
 }: CreateXudOrderParams): Observable<PlaceOrderResponse> => {
   if (quantity > 0) {
+    const CREATING_OR_REPLACING = replaceOrderId ? 'Replacing' : 'Creating';
     logger.trace(
-      `Creating ${pairId} ${
+      `${CREATING_OR_REPLACING} ${pairId} ${
         orderSideMapping[orderSide]
       } order with id ${orderId}, quantity ${satsToCoinsStr(
         quantity
@@ -42,6 +44,9 @@ const createXudOrder$ = ({
     request.setPairId(pairId);
     request.setPrice(price);
     request.setOrderId(orderId);
+    if (replaceOrderId) {
+      request.setReplaceOrderId(replaceOrderId);
+    }
     const createXudOrder$ = new Observable(subscriber => {
       client.placeOrderSync(
         request,


### PR DESCRIPTION
This PR changes arby's logic to try `ReplaceOrder`. If the existing order does not exist it will use `PlaceOrder` instead. Previously it would issue 2 RPC calls `RemoveOrder` -> `PlaceOrder` each time it needed to update orders.

EDIT by @kilrau : closes https://github.com/ExchangeUnion/market-maker-tools/issues/23