### PR TITLE
fix: price throttle update

### DIFF
--- a/src/arby.ts
+++ b/src/arby.ts
@@ -15,6 +15,7 @@ import { removeOpenDEXorders$ } from './opendex/remove-orders';
 import { getCleanup$, GetCleanupParams } from './trade/cleanup';
 import { getNewTrade$, GetTradeParams } from './trade/trade';
 import { getStartShutdown$ } from './utils';
+import { getArbyStore } from './store';
 
 type StartArbyParams = {
   config$: Observable<Config>;
@@ -74,6 +75,7 @@ export const startArby = ({
   cleanup$,
   initBinance$,
 }: StartArbyParams): Observable<any> => {
+  const store = getArbyStore();
   return config$.pipe(
     mergeMap(config => {
       const CEX$ = initBinance$({
@@ -95,6 +97,7 @@ export const startArby = ({
             catchOpenDEXerror,
             getCentralizedExchangePrice$,
             CEX,
+            store,
           }).pipe(takeUntil(shutdown$));
           return concat(
             tradeComplete$,

--- a/src/centralized/order-builder.spec.ts
+++ b/src/centralized/order-builder.spec.ts
@@ -1,11 +1,12 @@
-import { getOrderBuilder$, CEXorder } from './order-builder';
-import { TestScheduler } from 'rxjs/testing';
-import { testConfig, getLoggers } from '../test-utils';
-import { Observable } from 'rxjs';
-import { SwapSuccess } from '../proto/xudrpc_pb';
-import { OrderSide, Asset } from '../constants';
 import BigNumber from 'bignumber.js';
+import { Observable } from 'rxjs';
+import { TestScheduler } from 'rxjs/testing';
 import { Config } from '../config';
+import { Asset, OrderSide } from '../constants';
+import { SwapSuccess } from '../proto/xudrpc_pb';
+import { ArbyStore, getArbyStore } from '../store';
+import { getLoggers, testConfig } from '../test-utils';
+import { CEXorder, getOrderBuilder$ } from './order-builder';
 
 let testScheduler: TestScheduler;
 
@@ -28,7 +29,8 @@ const assertOrderBuilder = (
     a: CEXorder;
   },
   config: Config,
-  expectedAssetToTradeOnCEX: Asset
+  expectedAssetToTradeOnCEX: Asset,
+  store?: ArbyStore
 ) => {
   testScheduler.run(helpers => {
     const { cold, expectObservable } = helpers;
@@ -59,6 +61,7 @@ const assertOrderBuilder = (
       accumulateOrderFillsForBaseAssetReceived: accumulateOrderFillsForAssetReceived,
       accumulateOrderFillsForQuoteAssetReceived: accumulateOrderFillsForAssetReceived,
       quantityAboveMinimum,
+      store: store ? store : getArbyStore(),
     });
     expectObservable(orderBuilder$, inputEvents.unsubscribe).toBe(
       expected,
@@ -83,6 +86,7 @@ describe('getCentralizedExchangeOrder$', () => {
   });
 
   it('accumulates buy and sell orders for ETHBTC', () => {
+    expect.assertions(6);
     const inputEvents = {
       receivedBaseAssetSwapSuccess$: '1s a',
       receivedQuoteAssetSwapSuccess$: '1400ms b',
@@ -117,17 +121,24 @@ describe('getCentralizedExchangeOrder$', () => {
       QUOTEASSET,
     };
     const expectedAssetToTradeOnCEX = BASEASSET;
+    const store = {
+      ...getArbyStore(),
+      ...{ updateLastPrice: jest.fn() },
+    };
     assertOrderBuilder(
       inputEvents,
       inputValues,
       expected,
       expectedValues,
       config,
-      expectedAssetToTradeOnCEX
+      expectedAssetToTradeOnCEX,
+      store
     );
+    expect(store.updateLastPrice).toHaveBeenCalledTimes(2);
   });
 
   it('accumulates buy and sell orders for BTCUSDT', () => {
+    expect.assertions(6);
     const inputEvents = {
       receivedBaseAssetSwapSuccess$: '1s a',
       receivedQuoteAssetSwapSuccess$: '1400ms b',
@@ -162,13 +173,19 @@ describe('getCentralizedExchangeOrder$', () => {
       QUOTEASSET,
     };
     const expectedAssetToTradeOnCEX = QUOTEASSET;
+    const store = {
+      ...getArbyStore(),
+      ...{ updateLastPrice: jest.fn() },
+    };
     assertOrderBuilder(
       inputEvents,
       inputValues,
       expected,
       expectedValues,
       config,
-      expectedAssetToTradeOnCEX
+      expectedAssetToTradeOnCEX,
+      store
     );
+    expect(store.updateLastPrice).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/centralized/order-builder.spec.ts
+++ b/src/centralized/order-builder.spec.ts
@@ -123,7 +123,7 @@ describe('getCentralizedExchangeOrder$', () => {
     const expectedAssetToTradeOnCEX = BASEASSET;
     const store = {
       ...getArbyStore(),
-      ...{ updateLastPrice: jest.fn() },
+      ...{ resetLastOrderUpdatePrice: jest.fn() },
     };
     assertOrderBuilder(
       inputEvents,
@@ -134,7 +134,7 @@ describe('getCentralizedExchangeOrder$', () => {
       expectedAssetToTradeOnCEX,
       store
     );
-    expect(store.updateLastPrice).toHaveBeenCalledTimes(2);
+    expect(store.resetLastOrderUpdatePrice).toHaveBeenCalledTimes(2);
   });
 
   it('accumulates buy and sell orders for BTCUSDT', () => {
@@ -175,7 +175,7 @@ describe('getCentralizedExchangeOrder$', () => {
     const expectedAssetToTradeOnCEX = QUOTEASSET;
     const store = {
       ...getArbyStore(),
-      ...{ updateLastPrice: jest.fn() },
+      ...{ resetLastOrderUpdatePrice: jest.fn() },
     };
     assertOrderBuilder(
       inputEvents,
@@ -186,6 +186,6 @@ describe('getCentralizedExchangeOrder$', () => {
       expectedAssetToTradeOnCEX,
       store
     );
-    expect(store.updateLastPrice).toHaveBeenCalledTimes(2);
+    expect(store.resetLastOrderUpdatePrice).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/centralized/order-builder.ts
+++ b/src/centralized/order-builder.ts
@@ -1,6 +1,6 @@
 import BigNumber from 'bignumber.js';
-import { merge, Observable } from 'rxjs';
-import { filter, map, repeat, take, tap } from 'rxjs/operators';
+import { merge, Observable, of } from 'rxjs';
+import { filter, map, repeat, take, tap, mergeMap } from 'rxjs/operators';
 import { Config } from '../config';
 import { OrderSide, Asset } from '../constants';
 import { Logger } from '../logger';
@@ -11,6 +11,7 @@ import {
 import { getXudClient$ } from '../opendex/xud/client';
 import { subscribeXudSwaps$ } from '../opendex/xud/subscribe-swaps';
 import { SwapSuccess } from '../proto/xudrpc_pb';
+import { ArbyStore } from '../store';
 
 type GetOrderBuilderParams = {
   config: Config;
@@ -29,6 +30,7 @@ type GetOrderBuilderParams = {
   quantityAboveMinimum: (
     asset: Asset
   ) => (filledQuantity: BigNumber) => boolean;
+  store: ArbyStore;
 };
 
 type CEXorder = {
@@ -43,6 +45,7 @@ const getOrderBuilder$ = ({
   accumulateOrderFillsForBaseAssetReceived,
   accumulateOrderFillsForQuoteAssetReceived,
   quantityAboveMinimum,
+  store,
 }: GetOrderBuilderParams): Observable<CEXorder> => {
   const {
     receivedBaseAssetSwapSuccess$,
@@ -58,10 +61,12 @@ const getOrderBuilder$ = ({
     // accumulate OpenDEX order fills when receiving
     // quote asset
     accumulateOrderFillsForQuoteAssetReceived(config),
-    tap((quantity: BigNumber) => {
+    mergeMap((quantity: BigNumber) => {
       logger.info(
         `Swap success. Accumulated ${assetToTradeOnCEX} quantity: ${quantity.toFixed()}`
       );
+      store.updateLastPrice(new BigNumber('0'));
+      return of(quantity);
     }),
     // filter based on minimum CEX order quantity
     filter(quantityAboveMinimum(assetToTradeOnCEX)),

--- a/src/centralized/order-builder.ts
+++ b/src/centralized/order-builder.ts
@@ -65,7 +65,7 @@ const getOrderBuilder$ = ({
       logger.info(
         `Swap success. Accumulated ${assetToTradeOnCEX} quantity: ${quantity.toFixed()}`
       );
-      store.updateLastPrice(new BigNumber('0'));
+      store.resetLastOrderUpdatePrice();
       return of(quantity);
     }),
     // filter based on minimum CEX order quantity

--- a/src/centralized/order.spec.ts
+++ b/src/centralized/order.spec.ts
@@ -5,6 +5,7 @@ import { getCentralizedExchangeOrder$ } from './order';
 import { CEXorder } from './order-builder';
 import BigNumber from 'bignumber.js';
 import { Exchange } from 'ccxt';
+import { getArbyStore } from '../store';
 
 let testScheduler: TestScheduler;
 
@@ -35,6 +36,7 @@ const assertCentralizedExchangeOrder = (
     ) as unknown) as Observable<BigNumber>;
     const CEX = (null as unknown) as Exchange;
     const deriveCEXorderQuantity = (order: any) => order;
+    const store = getArbyStore();
     const centralizedExchangeOrder$ = getCentralizedExchangeOrder$({
       CEX,
       logger: getLoggers().centralized,
@@ -43,6 +45,7 @@ const assertCentralizedExchangeOrder = (
       executeCEXorder$,
       centralizedExchangePrice$,
       deriveCEXorderQuantity,
+      store,
     });
     expectObservable(centralizedExchangeOrder$, inputEvents.unsubscribe).toBe(
       expected

--- a/src/centralized/order.ts
+++ b/src/centralized/order.ts
@@ -18,6 +18,7 @@ import { createOrder$ } from './ccxt/create-order';
 import { ExecuteCEXorderParams } from './execute-order';
 import { quantityAboveMinimum } from './minimum-order-quantity-filter';
 import { CEXorder, GetOrderBuilderParams } from './order-builder';
+import { ArbyStore } from 'src/store';
 
 type GetCentralizedExchangeOrderParams = {
   CEX: Exchange;
@@ -41,6 +42,7 @@ type GetCentralizedExchangeOrderParams = {
     price: BigNumber,
     config: Config
   ) => CEXorder;
+  store: ArbyStore;
 };
 
 const getCentralizedExchangeOrder$ = ({
@@ -51,6 +53,7 @@ const getCentralizedExchangeOrder$ = ({
   getOrderBuilder$,
   centralizedExchangePrice$,
   deriveCEXorderQuantity,
+  store,
 }: GetCentralizedExchangeOrderParams): Observable<null> => {
   return getOrderBuilder$({
     config,
@@ -59,6 +62,7 @@ const getCentralizedExchangeOrder$ = ({
     accumulateOrderFillsForBaseAssetReceived,
     accumulateOrderFillsForQuoteAssetReceived,
     quantityAboveMinimum,
+    store,
   }).pipe(
     withLatestFrom(
       centralizedExchangePrice$.pipe(

--- a/src/opendex/catch-error.spec.ts
+++ b/src/opendex/catch-error.spec.ts
@@ -2,11 +2,9 @@ import { status } from '@grpc/grpc-js';
 import { AuthenticationError, Exchange } from 'ccxt';
 import { TestScheduler } from 'rxjs/testing';
 import { errors } from '../opendex/errors';
-import { getArbyStore, ArbyStore } from '../store';
+import { ArbyStore, getArbyStore } from '../store';
 import { getLoggers, testConfig, TestError } from '../test-utils';
 import { catchOpenDEXerror } from './catch-error';
-import BigNumber from 'bignumber.js';
-
 let testScheduler: TestScheduler;
 const testSchedulerSetup = () => {
   testScheduler = new TestScheduler((actual, expected) => {

--- a/src/opendex/catch-error.spec.ts
+++ b/src/opendex/catch-error.spec.ts
@@ -192,8 +192,8 @@ describe('catchOpenDEXerror', () => {
   });
 
   it('cancels orders, updates store lastPriceUpdate, retries CENTRALIZED_EXCHANGE_PRICE_FEED_ERROR', () => {
-    // 2 extra assertions after assertCatchOpenDEXerror
-    expect.assertions(ASSERTIONS_PER_TEST + 2);
+    // 1 extra assertion after assertCatchOpenDEXerror
+    expect.assertions(ASSERTIONS_PER_TEST + 1);
     const inputEvents = '1s #';
     const inputError = errors.CENTRALIZED_EXCHANGE_PRICE_FEED_ERROR;
     const expected = '';
@@ -203,7 +203,7 @@ describe('catchOpenDEXerror', () => {
     };
     const store = {
       ...getArbyStore(),
-      ...{ updateLastPrice: jest.fn() },
+      ...{ resetLastOrderUpdatePrice: jest.fn() },
     };
     const unsubscribe = '10s !';
     assertCatchOpenDEXerror({
@@ -214,8 +214,7 @@ describe('catchOpenDEXerror', () => {
       expectedSubscriptions,
       store,
     });
-    expect(store.updateLastPrice).toHaveBeenCalledTimes(2);
-    expect(store.updateLastPrice).toHaveBeenCalledWith(new BigNumber('0'));
+    expect(store.resetLastOrderUpdatePrice).toHaveBeenCalledTimes(2);
   });
 
   it('retries recoverable gRPC errors', () => {

--- a/src/opendex/catch-error.ts
+++ b/src/opendex/catch-error.ts
@@ -66,7 +66,7 @@ const catchOpenDEXerror = (
               e.code === errorCodes.CENTRALIZED_EXCHANGE_PRICE_FEED_ERROR
             ) {
               logMessage(loggers.centralized);
-              store.updateLastPrice(new BigNumber('0'));
+              store.resetLastOrderUpdatePrice();
               return concat(
                 getCleanup$({
                   config,

--- a/src/opendex/catch-error.ts
+++ b/src/opendex/catch-error.ts
@@ -66,6 +66,7 @@ const catchOpenDEXerror = (
               e.code === errorCodes.CENTRALIZED_EXCHANGE_PRICE_FEED_ERROR
             ) {
               logMessage(loggers.centralized);
+              store.updateLastPrice(new BigNumber('0'));
               return concat(
                 getCleanup$({
                   config,
@@ -73,13 +74,7 @@ const catchOpenDEXerror = (
                   removeOpenDEXorders$,
                   removeCEXorders$,
                   CEX,
-                }).pipe(
-                  mergeMap(() => {
-                    store.updateLastPrice(new BigNumber('0'));
-                    return of(null);
-                  }),
-                  ignoreElements()
-                ),
+                }).pipe(ignoreElements()),
                 timer(RETRY_INTERVAL)
               );
             }

--- a/src/opendex/catch-error.ts
+++ b/src/opendex/catch-error.ts
@@ -1,7 +1,6 @@
 import { status } from '@grpc/grpc-js';
-import BigNumber from 'bignumber.js';
 import { AuthenticationError, Exchange } from 'ccxt';
-import { concat, Observable, of, throwError, timer } from 'rxjs';
+import { concat, Observable, throwError, timer } from 'rxjs';
 import { ignoreElements, mergeMap, retryWhen } from 'rxjs/operators';
 import { ArbyStore } from 'src/store';
 import { removeCEXorders$ } from '../centralized/remove-orders';

--- a/src/opendex/complete.spec.ts
+++ b/src/opendex/complete.spec.ts
@@ -1,6 +1,6 @@
 import BigNumber from 'bignumber.js';
 import { Exchange } from 'ccxt';
-import { Observable } from 'rxjs';
+import { BehaviorSubject, Observable } from 'rxjs';
 import { TestScheduler } from 'rxjs/testing';
 import { getLoggers, testConfig } from '../test-utils';
 import { TradeInfo } from '../trade/info';
@@ -39,6 +39,7 @@ const assertGetOpenDEXcomplete = (
       BigNumber
     >;
     const CEX = (null as unknown) as Exchange;
+    const lastPriceUpdateStore = new BehaviorSubject(new BigNumber('0'));
     const trade$ = getOpenDEXcomplete$({
       CEX,
       config: testConfig(),
@@ -46,6 +47,7 @@ const assertGetOpenDEXcomplete = (
       tradeInfo$: getTradeInfo$,
       createOpenDEXorders$,
       centralizedExchangePrice$,
+      lastPriceUpdateStore,
     });
     expectObservable(trade$).toBe(expected, { a: true });
   });

--- a/src/opendex/complete.spec.ts
+++ b/src/opendex/complete.spec.ts
@@ -1,7 +1,8 @@
 import BigNumber from 'bignumber.js';
 import { Exchange } from 'ccxt';
-import { BehaviorSubject, Observable } from 'rxjs';
+import { Observable } from 'rxjs';
 import { TestScheduler } from 'rxjs/testing';
+import { getArbyStore } from '../store';
 import { getLoggers, testConfig } from '../test-utils';
 import { TradeInfo } from '../trade/info';
 import { getOpenDEXcomplete$ } from './complete';
@@ -39,7 +40,7 @@ const assertGetOpenDEXcomplete = (
       BigNumber
     >;
     const CEX = (null as unknown) as Exchange;
-    const lastPriceUpdateStore = new BehaviorSubject(new BigNumber('0'));
+    const store = getArbyStore();
     const trade$ = getOpenDEXcomplete$({
       CEX,
       config: testConfig(),
@@ -47,7 +48,7 @@ const assertGetOpenDEXcomplete = (
       tradeInfo$: getTradeInfo$,
       createOpenDEXorders$,
       centralizedExchangePrice$,
-      lastPriceUpdateStore,
+      store,
     });
     expectObservable(trade$).toBe(expected, { a: true });
   });

--- a/src/opendex/complete.ts
+++ b/src/opendex/complete.ts
@@ -1,10 +1,11 @@
 import { BigNumber } from 'bignumber.js';
 import { Exchange } from 'ccxt';
-import { empty, Observable, of, BehaviorSubject } from 'rxjs';
+import { empty, Observable, of } from 'rxjs';
 import { exhaustMap, mergeMap, take } from 'rxjs/operators';
 import { getCentralizedExchangeAssets$ } from '../centralized/assets';
 import { Config } from '../config';
 import { Loggers } from '../logger';
+import { ArbyStore } from '../store';
 import {
   GetTradeInfoParams,
   TradeInfo,
@@ -39,7 +40,7 @@ type GetOpenDEXcompleteParams = {
     createXudOrder$,
   }: CreateOpenDEXordersParams) => Observable<boolean>;
   centralizedExchangePrice$: Observable<BigNumber>;
-  lastPriceUpdateStore: BehaviorSubject<BigNumber>;
+  store: ArbyStore;
 };
 
 const getOpenDEXcomplete$ = ({
@@ -49,7 +50,7 @@ const getOpenDEXcomplete$ = ({
   tradeInfo$,
   createOpenDEXorders$,
   centralizedExchangePrice$,
-  lastPriceUpdateStore,
+  store,
 }: GetOpenDEXcompleteParams): Observable<boolean> => {
   const openDEXassetsWithConfig = (config: Config) => {
     return getOpenDEXassets$({
@@ -75,7 +76,7 @@ const getOpenDEXcomplete$ = ({
     // is already in progress
     exhaustMap((tradeInfo: TradeInfo) => {
       const getTradeInfo = () => tradeInfo;
-      return lastPriceUpdateStore.pipe(
+      return store.selectState('lastPriceUpdate').pipe(
         take(1),
         mergeMap((lastPriceUpdate: BigNumber) => {
           if (shouldCreateOpenDEXorders(tradeInfo.price, lastPriceUpdate)) {
@@ -90,7 +91,7 @@ const getOpenDEXcomplete$ = ({
             }).pipe(
               mergeMap(() => {
                 // store the last price update
-                lastPriceUpdateStore.next(tradeInfo.price);
+                store.updateLastPrice(tradeInfo.price);
                 return of(true);
               })
             );

--- a/src/opendex/complete.ts
+++ b/src/opendex/complete.ts
@@ -91,7 +91,7 @@ const getOpenDEXcomplete$ = ({
             }).pipe(
               mergeMap(() => {
                 // store the last price update
-                store.updateLastPrice(tradeInfo.price);
+                store.updateLastOrderUpdatePrice(tradeInfo.price);
                 return of(true);
               })
             );

--- a/src/opendex/complete.ts
+++ b/src/opendex/complete.ts
@@ -76,7 +76,7 @@ const getOpenDEXcomplete$ = ({
     // is already in progress
     exhaustMap((tradeInfo: TradeInfo) => {
       const getTradeInfo = () => tradeInfo;
-      return store.selectState('lastPriceUpdate').pipe(
+      return store.selectState('lastOrderUpdatePrice').pipe(
         take(1),
         mergeMap((lastPriceUpdate: BigNumber) => {
           if (shouldCreateOpenDEXorders(tradeInfo.price, lastPriceUpdate)) {

--- a/src/opendex/complete.ts
+++ b/src/opendex/complete.ts
@@ -1,6 +1,6 @@
 import { BigNumber } from 'bignumber.js';
 import { Exchange } from 'ccxt';
-import { BehaviorSubject, empty, Observable, of } from 'rxjs';
+import { empty, Observable, of, BehaviorSubject } from 'rxjs';
 import { exhaustMap, mergeMap, take } from 'rxjs/operators';
 import { getCentralizedExchangeAssets$ } from '../centralized/assets';
 import { Config } from '../config';
@@ -39,6 +39,7 @@ type GetOpenDEXcompleteParams = {
     createXudOrder$,
   }: CreateOpenDEXordersParams) => Observable<boolean>;
   centralizedExchangePrice$: Observable<BigNumber>;
+  lastPriceUpdateStore: BehaviorSubject<BigNumber>;
 };
 
 const getOpenDEXcomplete$ = ({
@@ -48,6 +49,7 @@ const getOpenDEXcomplete$ = ({
   tradeInfo$,
   createOpenDEXorders$,
   centralizedExchangePrice$,
+  lastPriceUpdateStore,
 }: GetOpenDEXcompleteParams): Observable<boolean> => {
   const openDEXassetsWithConfig = (config: Config) => {
     return getOpenDEXassets$({
@@ -60,7 +62,6 @@ const getOpenDEXcomplete$ = ({
       xudTradingLimits$: getXudTradingLimits$,
     });
   };
-  const lastPriceUpdateStore = new BehaviorSubject(new BigNumber('0'));
   return tradeInfo$({
     config,
     loggers,

--- a/src/store.spec.ts
+++ b/src/store.spec.ts
@@ -2,19 +2,19 @@ import { getArbyStore } from './store';
 import BigNumber from 'bignumber.js';
 
 describe('ArbyStore', () => {
-  it('selectState returns 0 as initial lastPriceUpdate', (done) => {
+  it('selectState returns 0 as initial lastPriceUpdate', done => {
     const { selectState } = getArbyStore();
-    selectState('lastPriceUpdate').subscribe((price) => {
+    selectState('lastPriceUpdate').subscribe(price => {
       expect(price).toEqual(new BigNumber('0'));
       done();
     });
   });
 
-  it('selectState returns updated last price', (done) => {
+  it('selectState returns updated last price', done => {
     const { selectState, updateLastPrice } = getArbyStore();
-    const updatedPrice = new BigNumber('123')
+    const updatedPrice = new BigNumber('123');
     updateLastPrice(updatedPrice);
-    selectState('lastPriceUpdate').subscribe((price) => {
+    selectState('lastPriceUpdate').subscribe(price => {
       expect(price).toEqual(updatedPrice);
       done();
     });

--- a/src/store.spec.ts
+++ b/src/store.spec.ts
@@ -11,9 +11,9 @@ describe('ArbyStore', () => {
   });
 
   it('selectState returns updated last price', done => {
-    const { selectState, updateLastPrice } = getArbyStore();
+    const { selectState, updateLastOrderUpdatePrice } = getArbyStore();
     const updatedPrice = new BigNumber('123');
-    updateLastPrice(updatedPrice);
+    updateLastOrderUpdatePrice(updatedPrice);
     selectState('lastPriceUpdate').subscribe(price => {
       expect(price).toEqual(updatedPrice);
       done();
@@ -21,9 +21,9 @@ describe('ArbyStore', () => {
   });
 
   it('reset lastOrderUpdatePrice', done => {
-    const { selectState, updateLastPrice, resetLastOrderUpdatePrice } = getArbyStore();
+    const { selectState, updateLastOrderUpdatePrice, resetLastOrderUpdatePrice } = getArbyStore();
     const updatedPrice = new BigNumber('123');
-    updateLastPrice(updatedPrice);
+    updateLastOrderUpdatePrice(updatedPrice);
     resetLastOrderUpdatePrice();
     selectState('lastPriceUpdate').subscribe(price => {
       expect(price).toEqual(new BigNumber('0'));

--- a/src/store.spec.ts
+++ b/src/store.spec.ts
@@ -19,4 +19,15 @@ describe('ArbyStore', () => {
       done();
     });
   });
+
+  it('reset lastOrderUpdatePrice', done => {
+    const { selectState, updateLastPrice, resetLastOrderUpdatePrice } = getArbyStore();
+    const updatedPrice = new BigNumber('123');
+    updateLastPrice(updatedPrice);
+    resetLastOrderUpdatePrice();
+    selectState('lastPriceUpdate').subscribe(price => {
+      expect(price).toEqual(new BigNumber('0'));
+      done();
+    });
+  });
 });

--- a/src/store.spec.ts
+++ b/src/store.spec.ts
@@ -1,0 +1,22 @@
+import { getArbyStore } from './store';
+import BigNumber from 'bignumber.js';
+
+describe('ArbyStore', () => {
+  it('selectState returns 0 as initial lastPriceUpdate', (done) => {
+    const { selectState } = getArbyStore();
+    selectState('lastPriceUpdate').subscribe((price) => {
+      expect(price).toEqual(new BigNumber('0'));
+      done();
+    });
+  });
+
+  it('selectState returns updated last price', (done) => {
+    const { selectState, updateLastPrice } = getArbyStore();
+    const updatedPrice = new BigNumber('123')
+    updateLastPrice(updatedPrice);
+    selectState('lastPriceUpdate').subscribe((price) => {
+      expect(price).toEqual(updatedPrice);
+      done();
+    });
+  });
+});

--- a/src/store.spec.ts
+++ b/src/store.spec.ts
@@ -2,9 +2,9 @@ import { getArbyStore } from './store';
 import BigNumber from 'bignumber.js';
 
 describe('ArbyStore', () => {
-  it('selectState returns 0 as initial lastPriceUpdate', done => {
+  it('selectState returns 0 as initial lastOrderUpdatePrice', done => {
     const { selectState } = getArbyStore();
-    selectState('lastPriceUpdate').subscribe(price => {
+    selectState('lastOrderUpdatePrice').subscribe(price => {
       expect(price).toEqual(new BigNumber('0'));
       done();
     });
@@ -14,18 +14,22 @@ describe('ArbyStore', () => {
     const { selectState, updateLastOrderUpdatePrice } = getArbyStore();
     const updatedPrice = new BigNumber('123');
     updateLastOrderUpdatePrice(updatedPrice);
-    selectState('lastPriceUpdate').subscribe(price => {
+    selectState('lastOrderUpdatePrice').subscribe(price => {
       expect(price).toEqual(updatedPrice);
       done();
     });
   });
 
   it('reset lastOrderUpdatePrice', done => {
-    const { selectState, updateLastOrderUpdatePrice, resetLastOrderUpdatePrice } = getArbyStore();
+    const {
+      selectState,
+      updateLastOrderUpdatePrice,
+      resetLastOrderUpdatePrice,
+    } = getArbyStore();
     const updatedPrice = new BigNumber('123');
     updateLastOrderUpdatePrice(updatedPrice);
     resetLastOrderUpdatePrice();
-    selectState('lastPriceUpdate').subscribe(price => {
+    selectState('lastOrderUpdatePrice').subscribe(price => {
       expect(price).toEqual(new BigNumber('0'));
       done();
     });

--- a/src/store.ts
+++ b/src/store.ts
@@ -4,6 +4,7 @@ import { scan, pluck, distinctUntilKeyChanged } from 'rxjs/operators';
 
 type ArbyStore = {
   updateLastPrice: (price: BigNumber) => void;
+  resetLastOrderUpdatePrice: () => void;
   selectState: (stateKey: ArbyStoreDataKeys) => Observable<BigNumber>;
 };
 
@@ -31,12 +32,19 @@ const getArbyStore = (): ArbyStore => {
       lastPriceUpdate: price,
     });
   };
+
+  const resetLastOrderUpdatePrice = () => {
+    stateUpdates.next({
+      lastPriceUpdate: new BigNumber('0'),
+    });
+  };
   const selectState = (stateKey: ArbyStoreDataKeys) => {
     return store.pipe(distinctUntilKeyChanged(stateKey), pluck(stateKey));
   };
   return {
     updateLastPrice,
     selectState,
+    resetLastOrderUpdatePrice,
   };
 };
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -3,8 +3,8 @@ import { BehaviorSubject, Subject, Observable } from 'rxjs';
 import { scan, pluck, distinctUntilKeyChanged } from 'rxjs/operators';
 
 type ArbyStore = {
-  updateLastPrice: (price: BigNumber) => void
-  selectState: (stateKey: ArbyStoreDataKeys) => Observable<BigNumber>
+  updateLastPrice: (price: BigNumber) => void;
+  selectState: (stateKey: ArbyStoreDataKeys) => Observable<BigNumber>;
 };
 
 type ArbyStoreData = {
@@ -40,4 +40,4 @@ const getArbyStore = (): ArbyStore => {
   };
 };
 
-export { getArbyStore };
+export { getArbyStore, ArbyStore };

--- a/src/store.ts
+++ b/src/store.ts
@@ -9,14 +9,14 @@ type ArbyStore = {
 };
 
 type ArbyStoreData = {
-  lastPriceUpdate: BigNumber;
+  lastOrderUpdatePrice: BigNumber;
 };
 
 type ArbyStoreDataKeys = keyof ArbyStoreData;
 
 const getArbyStore = (): ArbyStore => {
   const initialState: ArbyStoreData = {
-    lastPriceUpdate: new BigNumber('0'),
+    lastOrderUpdatePrice: new BigNumber('0'),
   };
   const store = new BehaviorSubject(initialState);
   const stateUpdates = new Subject() as Subject<Partial<ArbyStoreData>>;
@@ -29,13 +29,13 @@ const getArbyStore = (): ArbyStore => {
     .subscribe(store);
   const updateLastOrderUpdatePrice = (price: BigNumber) => {
     stateUpdates.next({
-      lastPriceUpdate: price,
+      lastOrderUpdatePrice: price,
     });
   };
 
   const resetLastOrderUpdatePrice = () => {
     stateUpdates.next({
-      lastPriceUpdate: new BigNumber('0'),
+      lastOrderUpdatePrice: new BigNumber('0'),
     });
   };
   const selectState = (stateKey: ArbyStoreDataKeys) => {

--- a/src/store.ts
+++ b/src/store.ts
@@ -3,7 +3,7 @@ import { BehaviorSubject, Subject, Observable } from 'rxjs';
 import { scan, pluck, distinctUntilKeyChanged } from 'rxjs/operators';
 
 type ArbyStore = {
-  updateLastPrice: (price: BigNumber) => void;
+  updateLastOrderUpdatePrice: (price: BigNumber) => void;
   resetLastOrderUpdatePrice: () => void;
   selectState: (stateKey: ArbyStoreDataKeys) => Observable<BigNumber>;
 };
@@ -27,7 +27,7 @@ const getArbyStore = (): ArbyStore => {
       }, initialState)
     )
     .subscribe(store);
-  const updateLastPrice = (price: BigNumber) => {
+  const updateLastOrderUpdatePrice = (price: BigNumber) => {
     stateUpdates.next({
       lastPriceUpdate: price,
     });
@@ -42,7 +42,7 @@ const getArbyStore = (): ArbyStore => {
     return store.pipe(distinctUntilKeyChanged(stateKey), pluck(stateKey));
   };
   return {
-    updateLastPrice,
+    updateLastOrderUpdatePrice,
     selectState,
     resetLastOrderUpdatePrice,
   };

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,0 +1,43 @@
+import BigNumber from 'bignumber.js';
+import { BehaviorSubject, Subject, Observable } from 'rxjs';
+import { scan, pluck, distinctUntilKeyChanged } from 'rxjs/operators';
+
+type ArbyStore = {
+  updateLastPrice: (price: BigNumber) => void
+  selectState: (stateKey: ArbyStoreDataKeys) => Observable<BigNumber>
+};
+
+type ArbyStoreData = {
+  lastPriceUpdate: BigNumber;
+};
+
+type ArbyStoreDataKeys = keyof ArbyStoreData;
+
+const getArbyStore = (): ArbyStore => {
+  const initialState: ArbyStoreData = {
+    lastPriceUpdate: new BigNumber('0'),
+  };
+  const store = new BehaviorSubject(initialState);
+  const stateUpdates = new Subject() as Subject<Partial<ArbyStoreData>>;
+  stateUpdates
+    .pipe(
+      scan((acc, curr) => {
+        return { ...acc, ...curr };
+      }, initialState)
+    )
+    .subscribe(store);
+  const updateLastPrice = (price: BigNumber) => {
+    stateUpdates.next({
+      lastPriceUpdate: price,
+    });
+  };
+  const selectState = (stateKey: ArbyStoreDataKeys) => {
+    return store.pipe(distinctUntilKeyChanged(stateKey), pluck(stateKey));
+  };
+  return {
+    updateLastPrice,
+    selectState,
+  };
+};
+
+export { getArbyStore };

--- a/src/trade/trade.spec.ts
+++ b/src/trade/trade.spec.ts
@@ -1,10 +1,11 @@
+import BigNumber from 'bignumber.js';
+import { Exchange } from 'ccxt';
 import { Observable } from 'rxjs';
 import { catchError } from 'rxjs/operators';
 import { TestScheduler } from 'rxjs/testing';
+import { getArbyStore } from '../store';
 import { getLoggers, testConfig, TestError } from '../test-utils';
 import { getNewTrade$ } from './trade';
-import BigNumber from 'bignumber.js';
-import { Exchange } from 'ccxt';
 
 let testScheduler: TestScheduler;
 const testSchedulerSetup = () => {
@@ -73,6 +74,7 @@ const assertGetTrade = ({
       return (cold('') as unknown) as Observable<BigNumber>;
     };
     const CEX = (null as unknown) as Exchange;
+    const store = getArbyStore();
     const trade$ = getNewTrade$({
       CEX,
       shutdown$,
@@ -82,6 +84,7 @@ const assertGetTrade = ({
       getCentralizedExchangeOrder$,
       catchOpenDEXerror,
       getCentralizedExchangePrice$,
+      store,
     });
     expectObservable(trade$).toBe(expected, { a: true }, expectedError);
   });

--- a/src/trade/trade.ts
+++ b/src/trade/trade.ts
@@ -85,6 +85,7 @@ const getNewTrade$ = ({
       executeCEXorder$,
       centralizedExchangePrice$,
       deriveCEXorderQuantity,
+      store,
     })
   ).pipe(
     tap(() => {

--- a/src/trade/trade.ts
+++ b/src/trade/trade.ts
@@ -1,6 +1,6 @@
 import BigNumber from 'bignumber.js';
 import { Exchange } from 'ccxt';
-import { merge, Observable } from 'rxjs';
+import { BehaviorSubject, merge, Observable } from 'rxjs';
 import { ignoreElements, mapTo, repeat, takeUntil, tap } from 'rxjs/operators';
 import { deriveCEXorderQuantity } from '../centralized/derive-order-quantity';
 import { CentralizedExchangePriceParams } from '../centralized/exchange-price';
@@ -60,6 +60,7 @@ const getNewTrade$ = ({
     config,
     logger: loggers.centralized,
   });
+  const lastPriceUpdateStore = new BehaviorSubject(new BigNumber('0'));
   return merge(
     getOpenDEXcomplete$({
       config,
@@ -68,6 +69,7 @@ const getNewTrade$ = ({
       loggers,
       tradeInfo$: getTradeInfo$,
       centralizedExchangePrice$,
+      lastPriceUpdateStore,
     }).pipe(
       catchOpenDEXerror(loggers, config, getCleanup$, CEX),
       ignoreElements()


### PR DESCRIPTION
- last update price is now reset when price feed is lost -> new orders are now issued immediately
- last update price is reset when receiving a swap success event from xud