### PR TITLE
fix: order throttling follow-up fixes

### DIFF
--- a/src/centralized/exchange-price.ts
+++ b/src/centralized/exchange-price.ts
@@ -1,6 +1,11 @@
 import BigNumber from 'bignumber.js';
 import { Observable, throwError } from 'rxjs';
-import { catchError, timeout, share } from 'rxjs/operators';
+import {
+  catchError,
+  timeout,
+  share,
+  distinctUntilChanged,
+} from 'rxjs/operators';
 import WebSocket from 'ws';
 import { Config } from '../config';
 import { Logger } from '../logger';
@@ -55,6 +60,7 @@ const getCentralizedExchangePrice$ = ({
     catchError(() => {
       return throwError(errors.CENTRALIZED_EXCHANGE_PRICE_FEED_ERROR);
     }),
+    distinctUntilChanged((a, b) => a.isEqualTo(b)),
     share()
   );
 };

--- a/src/centralized/order-builder.spec.ts
+++ b/src/centralized/order-builder.spec.ts
@@ -134,7 +134,7 @@ describe('getCentralizedExchangeOrder$', () => {
       expectedAssetToTradeOnCEX,
       store
     );
-    expect(store.resetLastOrderUpdatePrice).toHaveBeenCalledTimes(2);
+    expect(store.resetLastOrderUpdatePrice).toHaveBeenCalledTimes(4);
   });
 
   it('accumulates buy and sell orders for BTCUSDT', () => {
@@ -186,6 +186,6 @@ describe('getCentralizedExchangeOrder$', () => {
       expectedAssetToTradeOnCEX,
       store
     );
-    expect(store.resetLastOrderUpdatePrice).toHaveBeenCalledTimes(2);
+    expect(store.resetLastOrderUpdatePrice).toHaveBeenCalledTimes(4);
   });
 });

--- a/src/centralized/order-builder.ts
+++ b/src/centralized/order-builder.ts
@@ -1,8 +1,8 @@
 import BigNumber from 'bignumber.js';
 import { merge, Observable, of } from 'rxjs';
-import { filter, map, repeat, take, tap, mergeMap } from 'rxjs/operators';
+import { filter, map, mergeMap, repeat, take } from 'rxjs/operators';
 import { Config } from '../config';
-import { OrderSide, Asset } from '../constants';
+import { Asset, OrderSide } from '../constants';
 import { Logger } from '../logger';
 import {
   GetOpenDEXswapSuccessParams,
@@ -82,10 +82,12 @@ const getOrderBuilder$ = ({
     // accumulate OpenDEX order fills when receiving
     // quote asset
     accumulateOrderFillsForBaseAssetReceived(config),
-    tap((quantity: BigNumber) => {
+    mergeMap((quantity: BigNumber) => {
       logger.info(
         `Swap success. Accumulated ${assetToTradeOnCEX} quantity: ${quantity.toFixed()}`
       );
+      store.resetLastOrderUpdatePrice();
+      return of(quantity);
     }),
     // filter based on minimum CEX order quantity
     filter(quantityAboveMinimum(assetToTradeOnCEX)),

--- a/src/opendex/complete.spec.ts
+++ b/src/opendex/complete.spec.ts
@@ -75,23 +75,4 @@ describe('getOpenDEXcomplete$', () => {
     };
     assertGetOpenDEXcomplete(inputEvents, expected, inputValues);
   });
-
-  test('filters by shouldCreateOpenDEXorders', () => {
-    const inputEvents = {
-      tradeInfo$: 'a ^ 1000ms a 1500ms a 500ms b',
-      getOpenDEXorders$: '1s a|',
-    };
-    const inputValues = {
-      tradeInfo$: {
-        a: {
-          price: new BigNumber('10000'),
-        },
-        b: {
-          price: new BigNumber('10010.1'),
-        },
-      },
-    };
-    const expected = '2s a 2001ms a';
-    assertGetOpenDEXcomplete(inputEvents, expected, inputValues);
-  });
 });

--- a/src/opendex/create-orders.spec.ts
+++ b/src/opendex/create-orders.spec.ts
@@ -3,10 +3,10 @@ import { Observable } from 'rxjs';
 import { TestScheduler } from 'rxjs/testing';
 import { XudClient } from '../proto/xudrpc_grpc_pb';
 import { PlaceOrderResponse } from '../proto/xudrpc_pb';
-import { getLoggers, testConfig } from '../test-utils';
+import { getArbyStore, ArbyStore } from '../store';
+import { getLoggers, testConfig, TestError } from '../test-utils';
 import { TradeInfo } from '../trade/info';
 import { createOpenDEXorders$, OpenDEXorders } from './create-orders';
-import { TestError } from '../test-utils';
 
 let testScheduler: TestScheduler;
 const testSchedulerSetup = () => {
@@ -21,14 +21,22 @@ type CreateOpenDEXordersInputEvents = {
   replaceXudOrder$: string;
 };
 
-const assertCreateOpenDEXorders = (
-  inputEvents: CreateOpenDEXordersInputEvents,
-  expected: string,
+const assertCreateOpenDEXorders = ({
+  expected,
+  inputEvents,
+  inputErrors,
+  store,
+  shouldCreateOpenDEXorders,
+}: {
+  inputEvents: CreateOpenDEXordersInputEvents;
+  expected: string;
   inputErrors?: {
     xudOrder$?: TestError;
     replaceXudOrder$?: TestError;
-  }
-) => {
+  };
+  store?: ArbyStore;
+  shouldCreateOpenDEXorders?: () => boolean;
+}) => {
   testScheduler.run(helpers => {
     const { cold, expectObservable } = helpers;
     const getTradeInfo = (): TradeInfo => {
@@ -36,17 +44,17 @@ const assertCreateOpenDEXorders = (
     };
     const createXudOrder$ = (createOrderParams: any) => {
       if (createOrderParams.replaceOrderId) {
-        return cold(
+        return (cold(
           inputEvents.replaceXudOrder$,
-          {},
+          { a: 'order-response' },
           inputErrors?.replaceXudOrder$
-        ) as Observable<PlaceOrderResponse>;
+        ) as unknown) as Observable<PlaceOrderResponse>;
       } else {
-        return cold(
+        return (cold(
           inputEvents.xudOrder$,
-          {},
+          { a: 'order-response' },
           inputErrors?.xudOrder$
-        ) as Observable<PlaceOrderResponse>;
+        ) as unknown) as Observable<PlaceOrderResponse>;
       }
     };
     const getXudClient$ = () => {
@@ -62,6 +70,10 @@ const assertCreateOpenDEXorders = (
       tradeInfoToOpenDEXorders,
       logger: getLoggers().global,
       config: testConfig(),
+      store: store ? store : getArbyStore(),
+      shouldCreateOpenDEXorders: shouldCreateOpenDEXorders
+        ? shouldCreateOpenDEXorders
+        : () => true,
     });
     expectObservable(createOrders$).toBe(expected, {
       a: true,
@@ -79,17 +91,66 @@ describe('createOpenDEXorders$', () => {
       xudOrder$: '',
     };
     const expected = '2s (a|)';
-    assertCreateOpenDEXorders(inputEvents, expected);
+    const store = {
+      ...getArbyStore(),
+      ...{ updateLastOrderUpdatePrice: jest.fn() },
+    };
+    assertCreateOpenDEXorders({ inputEvents, expected, store });
+    expect(store.updateLastOrderUpdatePrice).toHaveBeenCalledTimes(2);
   });
 
-  it('throws if unknown error for repace order', () => {
+  it('filters by shouldCreateOpenDEXorders', () => {
+    const inputEvents = {
+      xudClient$: '1s a',
+      replaceXudOrder$: '1s (a|)',
+      xudOrder$: '',
+    };
+    // it returns true immediately without attempting to create orders
+    const expected = '1s (a|)';
+    const store = {
+      ...getArbyStore(),
+      ...{ updateLastOrderUpdatePrice: jest.fn() },
+    };
+    const selectStateSpy = jest.spyOn(store, 'selectState');
+    const shouldCreateOpenDEXorders = () => false;
+    assertCreateOpenDEXorders({
+      inputEvents,
+      expected,
+      store,
+      shouldCreateOpenDEXorders,
+    });
+    expect(store.updateLastOrderUpdatePrice).toHaveBeenCalledTimes(0);
+    expect(selectStateSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('will not update lastOrderUpdatePrice when orders not created', () => {
+    const inputEvents = {
+      xudClient$: '1s a',
+      replaceXudOrder$: '1s (b|)',
+      xudOrder$: '',
+    };
+    const expected = '2s (a|)';
+    const store = {
+      ...getArbyStore(),
+      ...{ updateLastOrderUpdatePrice: jest.fn() },
+    };
+    assertCreateOpenDEXorders({ inputEvents, expected, store });
+    expect(store.updateLastOrderUpdatePrice).toHaveBeenCalledTimes(0);
+  });
+
+  it('throws if unknown error for replace order', () => {
     const inputEvents = {
       xudClient$: '1s a',
       replaceXudOrder$: '1s #',
       xudOrder$: '',
     };
     const expected = '2s #';
-    assertCreateOpenDEXorders(inputEvents, expected);
+    const store = {
+      ...getArbyStore(),
+      ...{ updateLastOrderUpdatePrice: jest.fn() },
+    };
+    assertCreateOpenDEXorders({ inputEvents, expected, store });
+    expect(store.updateLastOrderUpdatePrice).toHaveBeenCalledTimes(0);
   });
 
   it('retries without replaceOrderId if grpc.NOT_FOUND error', () => {
@@ -105,6 +166,11 @@ describe('createOpenDEXorders$', () => {
       },
     };
     const expected = '3s (a|)';
-    assertCreateOpenDEXorders(inputEvents, expected, inputErrors);
+    const store = {
+      ...getArbyStore(),
+      ...{ updateLastOrderUpdatePrice: jest.fn() },
+    };
+    assertCreateOpenDEXorders({ inputEvents, expected, inputErrors, store });
+    expect(store.updateLastOrderUpdatePrice).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/opendex/create-orders.ts
+++ b/src/opendex/create-orders.ts
@@ -1,7 +1,7 @@
 import { status } from '@grpc/grpc-js';
 import BigNumber from 'bignumber.js';
 import { forkJoin, Observable, of, throwError } from 'rxjs';
-import { catchError, mapTo, mergeMap, take, tap } from 'rxjs/operators';
+import { catchError, mapTo, mergeMap, take } from 'rxjs/operators';
 import { Config } from '../config';
 import { Logger } from '../logger';
 import { XudClient } from '../proto/xudrpc_grpc_pb';
@@ -51,7 +51,6 @@ const createOpenDEXorders$ = ({
   shouldCreateOpenDEXorders,
 }: CreateOpenDEXordersParams): Observable<boolean> => {
   return getXudClient$(config).pipe(
-    tap(() => logger.trace('Starting to update OpenDEX orders')),
     // create new buy and sell orders
     mergeMap(client => {
       const tradeInfo = getTradeInfo();
@@ -138,7 +137,6 @@ const createOpenDEXorders$ = ({
         })
       );
     }),
-    tap(() => logger.trace('OpenDEX orders updated')),
     take(1)
   );
 };

--- a/src/store.spec.ts
+++ b/src/store.spec.ts
@@ -1,20 +1,38 @@
-import { getArbyStore } from './store';
 import BigNumber from 'bignumber.js';
+import { getArbyStore } from './store';
 
 describe('ArbyStore', () => {
-  it('selectState returns 0 as initial lastOrderUpdatePrice', done => {
+  it('selectState returns 0 as initial lastSellOrderUpdatePrice', done => {
     const { selectState } = getArbyStore();
-    selectState('lastOrderUpdatePrice').subscribe(price => {
+    selectState('lastSellOrderUpdatePrice').subscribe(price => {
       expect(price).toEqual(new BigNumber('0'));
       done();
     });
   });
 
-  it('selectState returns updated last price', done => {
-    const { selectState, updateLastOrderUpdatePrice } = getArbyStore();
+  it('selectState returns 0 as initial lastBuyOrderUpdatePrice', done => {
+    const { selectState } = getArbyStore();
+    selectState('lastBuyOrderUpdatePrice').subscribe(price => {
+      expect(price).toEqual(new BigNumber('0'));
+      done();
+    });
+  });
+
+  it('selectState returns updated last sell order price', done => {
+    const { selectState, updateLastSellOrderUpdatePrice } = getArbyStore();
     const updatedPrice = new BigNumber('123');
-    updateLastOrderUpdatePrice(updatedPrice);
-    selectState('lastOrderUpdatePrice').subscribe(price => {
+    updateLastSellOrderUpdatePrice(updatedPrice);
+    selectState('lastSellOrderUpdatePrice').subscribe(price => {
+      expect(price).toEqual(updatedPrice);
+      done();
+    });
+  });
+
+  it('selectState returns updated last buy order price', done => {
+    const { selectState, updateLastBuyOrderUpdatePrice } = getArbyStore();
+    const updatedPrice = new BigNumber('123');
+    updateLastBuyOrderUpdatePrice(updatedPrice);
+    selectState('lastBuyOrderUpdatePrice').subscribe(price => {
       expect(price).toEqual(updatedPrice);
       done();
     });
@@ -22,15 +40,18 @@ describe('ArbyStore', () => {
 
   it('reset lastOrderUpdatePrice', done => {
     const {
-      selectState,
-      updateLastOrderUpdatePrice,
+      stateChanges,
+      updateLastSellOrderUpdatePrice,
+      updateLastBuyOrderUpdatePrice,
       resetLastOrderUpdatePrice,
     } = getArbyStore();
     const updatedPrice = new BigNumber('123');
-    updateLastOrderUpdatePrice(updatedPrice);
+    updateLastSellOrderUpdatePrice(updatedPrice);
+    updateLastBuyOrderUpdatePrice(updatedPrice);
     resetLastOrderUpdatePrice();
-    selectState('lastOrderUpdatePrice').subscribe(price => {
-      expect(price).toEqual(new BigNumber('0'));
+    stateChanges().subscribe(state => {
+      expect(state.lastSellOrderUpdatePrice).toEqual(new BigNumber('0'));
+      expect(state.lastBuyOrderUpdatePrice).toEqual(new BigNumber('0'));
       done();
     });
   });

--- a/src/store.ts
+++ b/src/store.ts
@@ -3,20 +3,24 @@ import { BehaviorSubject, Subject, Observable } from 'rxjs';
 import { scan, pluck, distinctUntilKeyChanged } from 'rxjs/operators';
 
 type ArbyStore = {
-  updateLastOrderUpdatePrice: (price: BigNumber) => void;
+  updateLastSellOrderUpdatePrice: (price: BigNumber) => void;
+  updateLastBuyOrderUpdatePrice: (price: BigNumber) => void;
   resetLastOrderUpdatePrice: () => void;
   selectState: (stateKey: ArbyStoreDataKeys) => Observable<BigNumber>;
+  stateChanges: () => Observable<ArbyStoreData>;
 };
 
 type ArbyStoreData = {
-  lastOrderUpdatePrice: BigNumber;
+  lastSellOrderUpdatePrice: BigNumber;
+  lastBuyOrderUpdatePrice: BigNumber;
 };
 
 type ArbyStoreDataKeys = keyof ArbyStoreData;
 
 const getArbyStore = (): ArbyStore => {
   const initialState: ArbyStoreData = {
-    lastOrderUpdatePrice: new BigNumber('0'),
+    lastSellOrderUpdatePrice: new BigNumber('0'),
+    lastBuyOrderUpdatePrice: new BigNumber('0'),
   };
   const store = new BehaviorSubject(initialState);
   const stateUpdates = new Subject() as Subject<Partial<ArbyStoreData>>;
@@ -27,24 +31,34 @@ const getArbyStore = (): ArbyStore => {
       }, initialState)
     )
     .subscribe(store);
-  const updateLastOrderUpdatePrice = (price: BigNumber) => {
+  const updateLastSellOrderUpdatePrice = (price: BigNumber) => {
     stateUpdates.next({
-      lastOrderUpdatePrice: price,
+      lastSellOrderUpdatePrice: price,
     });
   };
-
+  const updateLastBuyOrderUpdatePrice = (price: BigNumber) => {
+    stateUpdates.next({
+      lastBuyOrderUpdatePrice: price,
+    });
+  };
   const resetLastOrderUpdatePrice = () => {
     stateUpdates.next({
-      lastOrderUpdatePrice: new BigNumber('0'),
+      lastSellOrderUpdatePrice: new BigNumber('0'),
+      lastBuyOrderUpdatePrice: new BigNumber('0'),
     });
   };
   const selectState = (stateKey: ArbyStoreDataKeys) => {
     return store.pipe(distinctUntilKeyChanged(stateKey), pluck(stateKey));
   };
+  const stateChanges = () => {
+    return store.asObservable();
+  };
   return {
-    updateLastOrderUpdatePrice,
+    updateLastSellOrderUpdatePrice,
+    updateLastBuyOrderUpdatePrice,
     selectState,
     resetLastOrderUpdatePrice,
+    stateChanges,
   };
 };
 


### PR DESCRIPTION
- replace orders after receiving quote asset (previously it only did so for receiving base asset)
- do not trigger last order update price update when orders were not created (quantity 0)
- divide lastOrderUpdatePrice into lastSellOrderUpdatePrice and lastBuyOrderUpdatePrice