### PR TITLE
feat(config): harden configuration checks

### DIFF
--- a/src/__snapshots__/config.spec.ts.snap
+++ b/src/__snapshots__/config.spec.ts.snap
@@ -1,3 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`checkConfigOptions does not allow LTC/LTC trading pair 1`] = `"Invalid trading pair LTC/LTC. Supported trading pairs are: ETH/BTC, BTC/USDT, LTC/BTC, LTC/USDT"`;
+exports[`checkConfigOptions LIVE_CEX disabled does not allow LTC/LTC trading pair 1`] = `"Invalid trading pair LTC/LTC. Supported trading pairs are: ETH/BTC, BTC/USDT, LTC/BTC, LTC/USDT"`;
+
+exports[`checkConfigOptions LIVE_CEX disabled requires TEST_CENTRALIZED_EXCHANGE_BASEASSET_BALANCE 1`] = `"Incomplete configuration. Please add the following options to .env or as environment variables: TEST_CENTRALIZED_EXCHANGE_BASEASSET_BALANCE"`;
+
+exports[`checkConfigOptions LIVE_CEX disabled requires TEST_CENTRALIZED_EXCHANGE_QUOTEASSET_BALANCE 1`] = `"Incomplete configuration. Please add the following options to .env or as environment variables: TEST_CENTRALIZED_EXCHANGE_QUOTEASSET_BALANCE"`;
+
+exports[`checkConfigOptions LIVE_CEX enabled requires CEX_API_KEY 1`] = `"Incomplete configuration. Please add the following options to .env or as environment variables: CEX_API_KEY"`;
+
+exports[`checkConfigOptions LIVE_CEX enabled requires CEX_API_SECRET 1`] = `"Incomplete configuration. Please add the following options to .env or as environment variables: CEX_API_SECRET"`;

--- a/src/config.spec.ts
+++ b/src/config.spec.ts
@@ -1,12 +1,10 @@
 import { checkConfigOptions } from './config';
 
 describe('checkConfigOptions', () => {
-  it('allows BTC/USDT trading pair', () => {
-    const dotEnvConfig = {
+  describe('LIVE_CEX disabled', () => {
+    const validLiveCEXdisabledConf = {
       LOG_LEVEL: 'trace',
       CEX: 'Binance',
-      CEX_API_KEY: '123',
-      CEX_API_SECRET: 'abc',
       DATA_DIR: '/some/data/path',
       OPENDEX_CERT_PATH: '/some/cert/path',
       OPENDEX_RPC_HOST: 'localhost',
@@ -18,15 +16,62 @@ describe('checkConfigOptions', () => {
       TEST_CENTRALIZED_EXCHANGE_QUOTEASSET_BALANCE: '123',
       LIVE_CEX: 'false',
     };
-    const verifiedConfig = checkConfigOptions(dotEnvConfig);
-    expect(verifiedConfig).toEqual({
-      ...dotEnvConfig,
-      LIVE_CEX: false,
+
+    it('allows BTC/USDT', () => {
+      expect.assertions(1);
+      const config = checkConfigOptions(validLiveCEXdisabledConf);
+      expect(config).toEqual({
+        ...config,
+        LIVE_CEX: false,
+      });
+    });
+
+    it('allows ETH/BTC trading pair', () => {
+      const config = checkConfigOptions({
+        ...validLiveCEXdisabledConf,
+        ...{ BASEASSET: 'ETH', QUOTEASSET: 'BTC' },
+      });
+      expect(config).toEqual({
+        ...config,
+        LIVE_CEX: false,
+      });
+    });
+
+    it('does not allow LTC/LTC trading pair', () => {
+      const config = {
+        ...validLiveCEXdisabledConf,
+        ...{ BASEASSET: 'LTC', QUOTEASSET: 'LTC' },
+      };
+      expect(() => {
+        checkConfigOptions(config);
+      }).toThrowErrorMatchingSnapshot();
+    });
+
+    it('requires TEST_CENTRALIZED_EXCHANGE_BASEASSET_BALANCE', () => {
+      expect.assertions(1);
+      const config = {
+        ...validLiveCEXdisabledConf,
+      };
+      delete config.TEST_CENTRALIZED_EXCHANGE_BASEASSET_BALANCE;
+      expect(() => {
+        checkConfigOptions(config);
+      }).toThrowErrorMatchingSnapshot();
+    });
+
+    it('requires TEST_CENTRALIZED_EXCHANGE_QUOTEASSET_BALANCE', () => {
+      expect.assertions(1);
+      const config = {
+        ...validLiveCEXdisabledConf,
+      };
+      delete config.TEST_CENTRALIZED_EXCHANGE_QUOTEASSET_BALANCE;
+      expect(() => {
+        checkConfigOptions(config);
+      }).toThrowErrorMatchingSnapshot();
     });
   });
 
-  it('allows ETH/BTC trading pair', () => {
-    const dotEnvConfig = {
+  describe('LIVE_CEX enabled', () => {
+    const validLiveCEXenabledConf = {
       LOG_LEVEL: 'trace',
       CEX: 'Binance',
       CEX_API_KEY: '123',
@@ -36,38 +81,51 @@ describe('checkConfigOptions', () => {
       OPENDEX_RPC_HOST: 'localhost',
       OPENDEX_RPC_PORT: '1234',
       MARGIN: '0.06',
-      BASEASSET: 'ETH',
-      QUOTEASSET: 'BTC',
-      TEST_CENTRALIZED_EXCHANGE_BASEASSET_BALANCE: '321',
-      TEST_CENTRALIZED_EXCHANGE_QUOTEASSET_BALANCE: '123',
-      LIVE_CEX: 'false',
+      BASEASSET: 'BTC',
+      QUOTEASSET: 'USDT',
+      LIVE_CEX: 'true',
     };
-    const verifiedConfig = checkConfigOptions(dotEnvConfig);
-    expect(verifiedConfig).toEqual({
-      ...dotEnvConfig,
-      LIVE_CEX: false,
-    });
-  });
 
-  it('does not allow LTC/LTC trading pair', () => {
-    const dotEnvConfig = {
-      LOG_LEVEL: 'trace',
-      CEX: 'Binance',
-      CEX_API_KEY: '123',
-      CEX_API_SECRET: 'abc',
-      DATA_DIR: '/some/data/path',
-      OPENDEX_CERT_PATH: '/some/cert/path',
-      OPENDEX_RPC_HOST: 'localhost',
-      OPENDEX_RPC_PORT: '1234',
-      MARGIN: '0.06',
-      BASEASSET: 'LTC',
-      QUOTEASSET: 'LTC',
-      TEST_CENTRALIZED_EXCHANGE_BASEASSET_BALANCE: '321',
-      TEST_CENTRALIZED_EXCHANGE_QUOTEASSET_BALANCE: '123',
-      LIVE_CEX: 'false',
-    };
-    expect(() => {
-      checkConfigOptions(dotEnvConfig);
-    }).toThrowErrorMatchingSnapshot();
+    it('allows BTC/USDT', () => {
+      expect.assertions(1);
+      const config = checkConfigOptions(validLiveCEXenabledConf);
+      expect(config).toEqual({
+        ...config,
+        LIVE_CEX: true,
+      });
+    });
+
+    it('allows ETH/BTC trading pair', () => {
+      const config = checkConfigOptions({
+        ...validLiveCEXenabledConf,
+        ...{ BASEASSET: 'ETH', QUOTEASSET: 'BTC' },
+      });
+      expect(config).toEqual({
+        ...config,
+        LIVE_CEX: true,
+      });
+    });
+
+    it('requires CEX_API_KEY', () => {
+      expect.assertions(1);
+      const config = {
+        ...validLiveCEXenabledConf,
+      };
+      delete config.CEX_API_KEY;
+      expect(() => {
+        checkConfigOptions(config);
+      }).toThrowErrorMatchingSnapshot();
+    });
+
+    it('requires CEX_API_SECRET', () => {
+      expect.assertions(1);
+      const config = {
+        ...validLiveCEXenabledConf,
+      };
+      delete config.CEX_API_SECRET;
+      expect(() => {
+        checkConfigOptions(config);
+      }).toThrowErrorMatchingSnapshot();
+    });
   });
 });

--- a/src/config.ts
+++ b/src/config.ts
@@ -24,8 +24,6 @@ export type Config = {
 const REQUIRED_CONFIGURATION_OPTIONS = [
   'LOG_LEVEL',
   'CEX',
-  'CEX_API_KEY',
-  'CEX_API_SECRET',
   'DATA_DIR',
   'OPENDEX_CERT_PATH',
   'OPENDEX_RPC_HOST',
@@ -33,9 +31,17 @@ const REQUIRED_CONFIGURATION_OPTIONS = [
   'MARGIN',
   'BASEASSET',
   'QUOTEASSET',
+  'LIVE_CEX',
+];
+
+const REQUIRED_CONFIGURATION_OPTIONS_LIVE_CEX_ENABLED = [
+  'CEX_API_KEY',
+  'CEX_API_SECRET',
+];
+
+const REQUIRED_CONFIGURATION_OPTIONS_LIVE_CEX_DISABLED = [
   'TEST_CENTRALIZED_EXCHANGE_BASEASSET_BALANCE',
   'TEST_CENTRALIZED_EXCHANGE_QUOTEASSET_BALANCE',
-  'LIVE_CEX',
 ];
 
 const setLogLevel = (logLevel: string): Level => {
@@ -64,15 +70,18 @@ const getEnvironmentConfig = (): DotenvParseOutput => {
 };
 
 const getMissingOptions = (config: DotenvParseOutput): string => {
-  return REQUIRED_CONFIGURATION_OPTIONS.reduce(
-    (missingOptions: string[], configOption) => {
+  const ADDITIONAL_CONF_OPTIONS =
+    config['LIVE_CEX'] === 'true'
+      ? REQUIRED_CONFIGURATION_OPTIONS_LIVE_CEX_ENABLED
+      : REQUIRED_CONFIGURATION_OPTIONS_LIVE_CEX_DISABLED;
+  return REQUIRED_CONFIGURATION_OPTIONS.concat(ADDITIONAL_CONF_OPTIONS)
+    .reduce((missingOptions: string[], configOption) => {
       if (!config[configOption]) {
         return missingOptions.concat(configOption);
       }
       return missingOptions;
-    },
-    []
-  ).join(', ');
+    }, [])
+    .join(', ');
 };
 
 const ALLOWED_TRADING_PAIRS: string[] = [

--- a/src/config.ts
+++ b/src/config.ts
@@ -54,18 +54,18 @@ const setLogLevel = (logLevel: string): Level => {
 };
 
 const getEnvironmentConfig = (): DotenvParseOutput => {
-  const environmentConfig = REQUIRED_CONFIGURATION_OPTIONS.reduce(
-    (envConfig: DotenvParseOutput, configOption) => {
-      if (process.env[configOption]) {
-        return {
-          ...envConfig,
-          [configOption]: process.env[configOption]!,
-        };
-      }
-      return envConfig;
-    },
-    {}
-  );
+  const environmentConfig = REQUIRED_CONFIGURATION_OPTIONS.concat(
+    REQUIRED_CONFIGURATION_OPTIONS_LIVE_CEX_ENABLED,
+    REQUIRED_CONFIGURATION_OPTIONS_LIVE_CEX_DISABLED
+  ).reduce((envConfig: DotenvParseOutput, configOption) => {
+    if (process.env[configOption]) {
+      return {
+        ...envConfig,
+        [configOption]: process.env[configOption]!,
+      };
+    }
+    return envConfig;
+  }, {});
   return environmentConfig;
 };
 


### PR DESCRIPTION
This PR adds checks around configuration validation:
- `CEX` configuration option is mandatory regardless of `LIVE_CEX` config value
- `CEX_API_KEY` and `CEX_API_SECRET` is required only when `LIVE_CEX=true`
- `TEST_CENTRALIZED_EXCHANGE_BASEASSET_BALANCE` and `TEST_CENTRALIZED_EXCHANGE_QUOTEASSET_BALANCE` is required only when `LIVE_CEX=false`