### PR TITLE
feat: Kraken follow-up fixes v2

### DIFF
--- a/src/__snapshots__/config.spec.ts.snap
+++ b/src/__snapshots__/config.spec.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`checkConfigOptions LIVE_CEX disabled does not allow LTC/LTC trading pair 1`] = `"Invalid trading pair LTC/LTC. Supported trading pairs are: ETH/BTC, BTC/USDT, LTC/BTC, LTC/USDT"`;
+exports[`checkConfigOptions LIVE_CEX disabled does not allow LTC/LTC trading pair 1`] = `"Invalid trading pair LTC/LTC. Supported trading pairs are: ETH/BTC, BTC/USDT, BTC/DAI, LTC/BTC, LTC/USDT"`;
 
 exports[`checkConfigOptions LIVE_CEX disabled requires TEST_CENTRALIZED_EXCHANGE_BASEASSET_BALANCE 1`] = `"Incomplete configuration. Please add the following options to .env or as environment variables: TEST_CENTRALIZED_EXCHANGE_BASEASSET_BALANCE"`;
 

--- a/src/arby.ts
+++ b/src/arby.ts
@@ -52,9 +52,11 @@ const logConfig = (config: Config, logger: Logger) => {
     TEST_CENTRALIZED_EXCHANGE_QUOTEASSET_BALANCE,
     TEST_CENTRALIZED_EXCHANGE_BASEASSET_BALANCE,
     LIVE_CEX,
+    CEX,
   } = config;
   logger.info(`Running with config:
 LIVE_CEX: ${LIVE_CEX}
+CEX: ${CEX}
 LOG_LEVEL: ${LOG_LEVEL}
 DATA_DIR: ${DATA_DIR}
 OPENDEX_CERT_PATH: ${OPENDEX_CERT_PATH}

--- a/src/centralized/ccxt/exchange.spec.ts
+++ b/src/centralized/ccxt/exchange.spec.ts
@@ -12,7 +12,7 @@ describe('getExchange', () => {
   it('initializes Binance with API key and secret', () => {
     const config = {
       ...testConfig(),
-      ...{ CEX: 'Binance' },
+      ...{ CEX: 'BINANCE' },
     };
     getExchange(config);
     expect(ccxt.binance).toHaveBeenCalledTimes(1);
@@ -27,7 +27,7 @@ describe('getExchange', () => {
   it('initializes Kraken with API key and secret', () => {
     const config = {
       ...testConfig(),
-      ...{ CEX: 'Kraken' },
+      ...{ CEX: 'KRAKEN' },
     };
     getExchange(config);
     expect(ccxt.kraken).toHaveBeenCalledTimes(1);

--- a/src/centralized/ccxt/exchange.ts
+++ b/src/centralized/ccxt/exchange.ts
@@ -3,12 +3,12 @@ import { Config } from '../../config';
 
 const getExchange = (config: Config): Exchange => {
   switch (config.CEX) {
-    case 'Binance':
+    case 'BINANCE':
       return new ccxt.binance({
         apiKey: config.CEX_API_KEY,
         secret: config.CEX_API_SECRET,
       });
-    case 'Kraken':
+    case 'KRAKEN':
       return new ccxt.kraken({
         apiKey: config.CEX_API_KEY,
         secret: config.CEX_API_SECRET,

--- a/src/config.spec.ts
+++ b/src/config.spec.ts
@@ -4,14 +4,14 @@ describe('checkConfigOptions', () => {
   describe('LIVE_CEX disabled', () => {
     const validLiveCEXdisabledConf = {
       LOG_LEVEL: 'trace',
-      CEX: 'Binance',
+      CEX: 'binance',
       DATA_DIR: '/some/data/path',
       OPENDEX_CERT_PATH: '/some/cert/path',
       OPENDEX_RPC_HOST: 'localhost',
       OPENDEX_RPC_PORT: '1234',
       MARGIN: '0.06',
-      BASEASSET: 'BTC',
-      QUOTEASSET: 'USDT',
+      BASEASSET: 'btc',
+      QUOTEASSET: 'usdt',
       TEST_CENTRALIZED_EXCHANGE_BASEASSET_BALANCE: '321',
       TEST_CENTRALIZED_EXCHANGE_QUOTEASSET_BALANCE: '123',
       LIVE_CEX: 'false',
@@ -22,18 +22,24 @@ describe('checkConfigOptions', () => {
       const config = checkConfigOptions(validLiveCEXdisabledConf);
       expect(config).toEqual({
         ...config,
+        CEX: 'BINANCE',
         LIVE_CEX: false,
+        BASEASSET: 'BTC',
+        QUOTEASSET: 'USDT',
       });
     });
 
     it('allows ETH/BTC trading pair', () => {
       const config = checkConfigOptions({
         ...validLiveCEXdisabledConf,
-        ...{ BASEASSET: 'ETH', QUOTEASSET: 'BTC' },
+        ...{ BASEASSET: 'eth', QUOTEASSET: 'btc' },
       });
       expect(config).toEqual({
         ...config,
+        CEX: 'BINANCE',
         LIVE_CEX: false,
+        BASEASSET: 'ETH',
+        QUOTEASSET: 'BTC',
       });
     });
 
@@ -73,7 +79,7 @@ describe('checkConfigOptions', () => {
   describe('LIVE_CEX enabled', () => {
     const validLiveCEXenabledConf = {
       LOG_LEVEL: 'trace',
-      CEX: 'Binance',
+      CEX: 'kraken',
       CEX_API_KEY: '123',
       CEX_API_SECRET: 'abc',
       DATA_DIR: '/some/data/path',
@@ -91,6 +97,7 @@ describe('checkConfigOptions', () => {
       const config = checkConfigOptions(validLiveCEXenabledConf);
       expect(config).toEqual({
         ...config,
+        CEX: 'KRAKEN',
         LIVE_CEX: true,
       });
     });
@@ -102,6 +109,7 @@ describe('checkConfigOptions', () => {
       });
       expect(config).toEqual({
         ...config,
+        CEX: 'KRAKEN',
         LIVE_CEX: true,
       });
     });

--- a/src/config.ts
+++ b/src/config.ts
@@ -87,6 +87,7 @@ const getMissingOptions = (config: DotenvParseOutput): string => {
 const ALLOWED_TRADING_PAIRS: string[] = [
   'ETH/BTC',
   'BTC/USDT',
+  'BTC/DAI',
   'LTC/BTC',
   'LTC/USDT',
 ];

--- a/src/config.ts
+++ b/src/config.ts
@@ -103,7 +103,7 @@ const checkConfigOptions = (dotEnvConfig: DotenvParseOutput): Config => {
       `Incomplete configuration. Please add the following options to .env or as environment variables: ${missingOptions}`
     );
   }
-  const tradingPair = `${config.BASEASSET}/${config.QUOTEASSET}`;
+  const tradingPair = `${config.BASEASSET}/${config.QUOTEASSET}`.toUpperCase();
   if (!ALLOWED_TRADING_PAIRS.includes(tradingPair)) {
     throw new Error(
       `Invalid trading pair ${tradingPair}. Supported trading pairs are: ${ALLOWED_TRADING_PAIRS.join(
@@ -115,6 +115,9 @@ const checkConfigOptions = (dotEnvConfig: DotenvParseOutput): Config => {
     ...config,
     LOG_LEVEL: setLogLevel(config.LOG_LEVEL),
     LIVE_CEX: config.LIVE_CEX === 'true' ? true : false,
+    CEX: config.CEX.toUpperCase(),
+    BASEASSET: config.BASEASSET.toUpperCase(),
+    QUOTEASSET: config.QUOTEASSET.toUpperCase(),
   };
   return verifiedConfig as Config;
 };


### PR DESCRIPTION
This PR:
- adds `BTC/DAI` to allowed trading pairs list
- logs `CEX` configuration value on startup
- makes `CEX`, `BASEASSET` and `QUOTEASSET` configuration options case insensitive